### PR TITLE
Allow Node.js >=12

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "bootstrap": "4.5.3"
   },
   "devDependencies": {},
+  "overrides": {
+    "graceful-fs": "^4.2.10"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
gulp 3 depends on graceful-fs 3 that does not support Node.js >=12 https://stackoverflow.com/a/58394828