### PR TITLE
Fix displaying of form tips

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -16598,6 +16598,10 @@ form.civiremote-event-register-form .form-item[data-drupal-selector=edit-confirm
   margin-top: 0;
 }
 
+form .custom-control {
+  z-index: initial;
+}
+
 .layout--twocol-section > .layout__region,
 .layout--threecol-section > .layout__region,
 .layout--fourcol-section > .layout__region {

--- a/assets/scss/drupal/_drupal.scss
+++ b/assets/scss/drupal/_drupal.scss
@@ -2,6 +2,7 @@
 @import 'module/civicrm';
 @import "module/civiremote";
 @import "module/civiremote_funding";
+@import "module/formtips";
 @import "module/layout_builder";
 
 @import "form/form-global";

--- a/assets/scss/drupal/module/_formtips.scss
+++ b/assets/scss/drupal/module/_formtips.scss
@@ -1,0 +1,11 @@
+// Rules for module Form Tips.
+// https://www.drupal.org/project/formtips
+
+form {
+  // If z-index of .custom-control is set to a concrete number, other
+  // custom-control elements overlap the tool tip because the tool tip is inside
+  // the respective custom-control.
+  .custom-control {
+    z-index: initial;
+  }
+}


### PR DESCRIPTION
If z-index of .custom-control is set to a concrete number, input fields of other controls overlap tool tips independent of the tool tips' z-index. See screenshot:
![image](https://github.com/systopia/bfd_systopia/assets/5405481/49469858-8eb8-4d1a-a458-989fa05f70ef)

Do you think we should not reduce this to `#funding-form`, but do this generally?