### PR TITLE
upgrade bootstrap to >=5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^7.0.1",
     "gulp-dart-sass": "^1.0.2",
-    "bootstrap": "4.5.3"
+    "bootstrap": ">=5.0.0"
   },
   "devDependencies": {},
   "overrides": {


### PR DESCRIPTION
I updated to bootstrap `5.0<` in order to address open CVE in `<5.0`



_systopia ref.: 26903_