### PR TITLE
Make the `input` field for files visible

### DIFF
--- a/templates/form/input--file.html.twig
+++ b/templates/form/input--file.html.twig
@@ -1,0 +1,17 @@
+{#
+/**
+ * @file
+ * Theme override for an 'input' #type form element.
+ *
+ * This overrides the template from the bfd theme to make the input field
+ * visible again. It's now like in Bootstrap.
+ *
+ * Available variables:
+ * - attributes: A list of HTML attributes for the input element.
+ * - children: Optional additional rendered elements.
+ *
+ * @see template_preprocess_input()
+ */
+#}
+
+<input{{ attributes.addclass('form-control-file') }}/>{{ children }}


### PR DESCRIPTION
In the `bfd` theme the `input` for files is [hidden and replaced by a label](https://git.drupalcode.org/project/bfd/-/blob/8.x-2.66/templates/form/input--file.html.twig?ref_type=tags) that is displayed as button. Thereby there's no visible change after a file has been chosen.

It now looks like this:
![grafik](https://github.com/user-attachments/assets/4c331788-3ba6-47f2-9efd-5164adf0495a)

This is similar to the [default in Bootstrap](https://getbootstrap.com/docs/4.6/components/forms/#form-controls).

systopia-reference: 27061
