### PR TITLE
Fix height of .custom-file

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -180,7 +180,7 @@ a {
   background-color: transparent;
 }
 a:hover {
-  color: #027ce1;
+  color: rgb(2.2087378641, 123.6893203883, 225.2912621359);
   text-decoration: none;
 }
 
@@ -1703,7 +1703,7 @@ pre code {
 .table {
   width: 100%;
   margin-bottom: 1rem;
-  color: #90a0b0;
+  color: rgb(143.875, 159.75, 175.625);
 }
 .table th,
 .table td {
@@ -1748,568 +1748,568 @@ pre code {
 }
 
 .table-hover tbody tr:hover {
-  color: #90a0b0;
+  color: rgb(143.875, 159.75, 175.625);
   background-color: rgba(0, 0, 0, 0.075);
 }
 
 .table-primary,
 .table-primary > th,
 .table-primary > td {
-  background-color: #c6e5fe;
+  background-color: rgb(197.88, 228.68, 254.44);
 }
 .table-primary th,
 .table-primary td,
 .table-primary thead th,
 .table-primary tbody + tbody {
-  border-color: #95cefe;
+  border-color: rgb(148.92, 206.12, 253.96);
 }
 
 .table-hover .table-primary:hover {
-  background-color: #addafe;
+  background-color: rgb(172.6275728155, 217.0440776699, 254.1924271845);
 }
 .table-hover .table-primary:hover > td,
 .table-hover .table-primary:hover > th {
-  background-color: #addafe;
+  background-color: rgb(172.6275728155, 217.0440776699, 254.1924271845);
 }
 
 .table-secondary,
 .table-secondary > th,
 .table-secondary > td {
-  background-color: #c7c9ce;
+  background-color: rgb(199, 201.24, 206.28);
 }
 .table-secondary th,
 .table-secondary td,
 .table-secondary thead th,
 .table-secondary tbody + tbody {
-  border-color: #979ba5;
+  border-color: rgb(151, 155.16, 164.52);
 }
 
 .table-hover .table-secondary:hover {
-  background-color: #b9bcc2;
+  background-color: rgb(185.3636363636, 188.1490909091, 194.4163636364);
 }
 .table-hover .table-secondary:hover > td,
 .table-hover .table-secondary:hover > th {
-  background-color: #b9bcc2;
+  background-color: rgb(185.3636363636, 188.1490909091, 194.4163636364);
 }
 
 .table-success,
 .table-success > th,
 .table-success > td {
-  background-color: #c3e6cb;
+  background-color: rgb(194.8, 230.36, 202.92);
 }
 .table-success th,
 .table-success td,
 .table-success thead th,
 .table-success tbody + tbody {
-  border-color: #8fd19e;
+  border-color: rgb(143.2, 209.24, 158.28);
 }
 
 .table-hover .table-success:hover {
-  background-color: #b1dfbb;
+  background-color: rgb(176.7059405941, 222.9540594059, 187.2665346535);
 }
 .table-hover .table-success:hover > td,
 .table-hover .table-success:hover > th {
-  background-color: #b1dfbb;
+  background-color: rgb(176.7059405941, 222.9540594059, 187.2665346535);
 }
 
 .table-info,
 .table-info > th,
 .table-info > td {
-  background-color: #bee5eb;
+  background-color: rgb(190.04, 228.96, 235.12);
 }
 .table-info th,
 .table-info td,
 .table-info thead th,
 .table-info tbody + tbody {
-  border-color: #86cfda;
+  border-color: rgb(134.36, 206.64, 218.08);
 }
 
 .table-hover .table-info:hover {
-  background-color: #abdde5;
+  background-color: rgb(170.5152475248, 221.1332673267, 229.1447524752);
 }
 .table-hover .table-info:hover > td,
 .table-hover .table-info:hover > th {
-  background-color: #abdde5;
+  background-color: rgb(170.5152475248, 221.1332673267, 229.1447524752);
 }
 
 .table-warning,
 .table-warning > th,
 .table-warning > td {
-  background-color: #ffeeba;
+  background-color: rgb(255, 237.64, 185.56);
 }
 .table-warning th,
 .table-warning td,
 .table-warning thead th,
 .table-warning tbody + tbody {
-  border-color: #ffdf7e;
+  border-color: rgb(255, 222.76, 126.04);
 }
 
 .table-hover .table-warning:hover {
-  background-color: #ffe8a1;
+  background-color: rgb(255, 231.265, 160.06);
 }
 .table-hover .table-warning:hover > td,
 .table-hover .table-warning:hover > th {
-  background-color: #ffe8a1;
+  background-color: rgb(255, 231.265, 160.06);
 }
 
 .table-danger,
 .table-danger > th,
 .table-danger > td {
-  background-color: #f5c6cb;
+  background-color: rgb(245.2, 198.44, 202.92);
 }
 .table-danger th,
 .table-danger td,
 .table-danger thead th,
 .table-danger tbody + tbody {
-  border-color: #ed969e;
+  border-color: rgb(236.8, 149.96, 158.28);
 }
 
 .table-hover .table-danger:hover {
-  background-color: #f1b0b7;
+  background-color: rgb(241.4341772152, 176.7058227848, 182.9073417722);
 }
 .table-hover .table-danger:hover > td,
 .table-hover .table-danger:hover > th {
-  background-color: #f1b0b7;
+  background-color: rgb(241.4341772152, 176.7058227848, 182.9073417722);
 }
 
 .table-light,
 .table-light > th,
 .table-light > td {
-  background-color: #fdfdfe;
+  background-color: rgb(253.04, 253.32, 253.6);
 }
 .table-light th,
 .table-light td,
 .table-light thead th,
 .table-light tbody + tbody {
-  border-color: #fbfcfc;
+  border-color: rgb(251.36, 251.88, 252.4);
 }
 
 .table-hover .table-light:hover {
-  background-color: #ececf6;
+  background-color: rgb(238.165, 240.57, 242.975);
 }
 .table-hover .table-light:hover > td,
 .table-hover .table-light:hover > th {
-  background-color: #ececf6;
+  background-color: rgb(238.165, 240.57, 242.975);
 }
 
 .table-dark,
 .table-dark > th,
 .table-dark > td {
-  background-color: #c6c8ca;
+  background-color: rgb(198.16, 199.84, 201.52);
 }
 .table-dark th,
 .table-dark td,
 .table-dark thead th,
 .table-dark tbody + tbody {
-  border-color: #95999c;
+  border-color: rgb(149.44, 152.56, 155.68);
 }
 
 .table-hover .table-dark:hover {
-  background-color: #b9bbbe;
+  background-color: rgb(185.0216751269, 187.09, 189.1583248731);
 }
 .table-hover .table-dark:hover > td,
 .table-hover .table-dark:hover > th {
-  background-color: #b9bbbe;
+  background-color: rgb(185.0216751269, 187.09, 189.1583248731);
 }
 
 .table-black,
 .table-black > th,
 .table-black > td {
-  background-color: #b8b8b8;
+  background-color: rgb(183.6, 183.6, 183.6);
 }
 .table-black th,
 .table-black td,
 .table-black thead th,
 .table-black tbody + tbody {
-  border-color: #7a7a7a;
+  border-color: rgb(122.4, 122.4, 122.4);
 }
 
 .table-hover .table-black:hover {
-  background-color: #ababab;
+  background-color: rgb(170.85, 170.85, 170.85);
 }
 .table-hover .table-black:hover > td,
 .table-hover .table-black:hover > th {
-  background-color: #ababab;
+  background-color: rgb(170.85, 170.85, 170.85);
 }
 
 .table-instagram,
 .table-instagram > th,
 .table-instagram > td {
-  background-color: #f7cad2;
+  background-color: rgb(247.44, 201.52, 210.2);
 }
 .table-instagram th,
 .table-instagram td,
 .table-instagram thead th,
 .table-instagram tbody + tbody {
-  border-color: #f19cac;
+  border-color: rgb(240.96, 155.68, 171.8);
 }
 
 .table-hover .table-instagram:hover {
-  background-color: #f4b4bf;
+  background-color: rgb(244.2817431193, 179.1782568807, 191.4844036697);
 }
 .table-hover .table-instagram:hover > td,
 .table-hover .table-instagram:hover > th {
-  background-color: #f4b4bf;
+  background-color: rgb(244.2817431193, 179.1782568807, 191.4844036697);
 }
 
 .table-facebook,
 .table-facebook > th,
 .table-facebook > td {
-  background-color: #c8d1e2;
+  background-color: rgb(200.12, 208.52, 226.44);
 }
 .table-facebook th,
 .table-facebook td,
 .table-facebook thead th,
 .table-facebook tbody + tbody {
-  border-color: #99a9ca;
+  border-color: rgb(153.08, 168.68, 201.96);
 }
 
 .table-hover .table-facebook:hover {
-  background-color: #b7c3d9;
+  background-color: rgb(183.3481879195, 194.3153020134, 217.7118120805);
 }
 .table-hover .table-facebook:hover > td,
 .table-hover .table-facebook:hover > th {
-  background-color: #b7c3d9;
+  background-color: rgb(183.3481879195, 194.3153020134, 217.7118120805);
 }
 
 .table-messenger,
 .table-messenger > th,
 .table-messenger > td {
-  background-color: #b8ddff;
+  background-color: rgb(183.6, 220.56, 255);
 }
 .table-messenger th,
 .table-messenger td,
 .table-messenger thead th,
 .table-messenger tbody + tbody {
-  border-color: #7abfff;
+  border-color: rgb(122.4, 191.04, 255);
 }
 
 .table-hover .table-messenger:hover {
-  background-color: #9fd1ff;
+  background-color: rgb(158.1, 208.26, 255);
 }
 .table-hover .table-messenger:hover > td,
 .table-hover .table-messenger:hover > th {
-  background-color: #9fd1ff;
+  background-color: rgb(158.1, 208.26, 255);
 }
 
 .table-youtube,
 .table-youtube > th,
 .table-youtube > td {
-  background-color: #f1c1c0;
+  background-color: rgb(241, 192.56, 192.28);
 }
 .table-youtube th,
 .table-youtube td,
 .table-youtube thead th,
 .table-youtube tbody + tbody {
-  border-color: #e58b8b;
+  border-color: rgb(229, 139.04, 138.52);
 }
 
 .table-hover .table-youtube:hover {
-  background-color: #ecacab;
+  background-color: rgb(236.3467153285, 171.806350365, 171.4332846715);
 }
 .table-hover .table-youtube:hover > td,
 .table-hover .table-youtube:hover > th {
-  background-color: #ecacab;
+  background-color: rgb(236.3467153285, 171.806350365, 171.4332846715);
 }
 
 .table-twitter,
 .table-twitter > th,
 .table-twitter > td {
-  background-color: #cfe8fa;
+  background-color: rgb(207.4, 231.76, 250.24);
 }
 .table-twitter th,
 .table-twitter td,
 .table-twitter thead th,
 .table-twitter tbody + tbody {
-  border-color: #a7d4f6;
+  border-color: rgb(166.6, 211.84, 246.16);
 }
 
 .table-hover .table-twitter:hover {
-  background-color: #b8ddf8;
+  background-color: rgb(184.2181818182, 220.4418181818, 247.9218181818);
 }
 .table-hover .table-twitter:hover > td,
 .table-hover .table-twitter:hover > th {
-  background-color: #b8ddf8;
+  background-color: rgb(184.2181818182, 220.4418181818, 247.9218181818);
 }
 
 .table-linkedin,
 .table-linkedin > th,
 .table-linkedin > td {
-  background-color: #b8d9ea;
+  background-color: rgb(183.6, 216.92, 234.28);
 }
 .table-linkedin th,
 .table-linkedin td,
 .table-linkedin thead th,
 .table-linkedin tbody + tbody {
-  border-color: #7ab8d9;
+  border-color: rgb(122.4, 184.28, 216.52);
 }
 
 .table-hover .table-linkedin:hover {
-  background-color: #a4cee4;
+  background-color: rgb(163.83556231, 206.3789665653, 228.54443769);
 }
 .table-hover .table-linkedin:hover > td,
 .table-hover .table-linkedin:hover > th {
-  background-color: #a4cee4;
+  background-color: rgb(163.83556231, 206.3789665653, 228.54443769);
 }
 
 .table-snapchat,
 .table-snapchat > th,
 .table-snapchat > td {
-  background-color: #fffeb8;
+  background-color: rgb(255, 254.16, 183.6);
 }
 .table-snapchat th,
 .table-snapchat td,
 .table-snapchat thead th,
 .table-snapchat tbody + tbody {
-  border-color: #fffd7a;
+  border-color: rgb(255, 253.44, 122.4);
 }
 
 .table-hover .table-snapchat:hover {
-  background-color: #fffe9f;
+  background-color: rgb(255, 253.86, 158.1);
 }
 .table-hover .table-snapchat:hover > td,
 .table-hover .table-snapchat:hover > th {
-  background-color: #fffe9f;
+  background-color: rgb(255, 253.86, 158.1);
 }
 
 .table-whatsapp,
 .table-whatsapp > th,
 .table-whatsapp > td {
-  background-color: #c2f3d4;
+  background-color: rgb(193.96, 242.68, 212.16);
 }
 .table-whatsapp th,
 .table-whatsapp td,
 .table-whatsapp thead th,
 .table-whatsapp tbody + tbody {
-  border-color: #8ee8af;
+  border-color: rgb(141.64, 232.12, 175.44);
 }
 
 .table-hover .table-whatsapp:hover {
-  background-color: #adefc5;
+  background-color: rgb(172.7424427481, 238.3975572519, 197.268778626);
 }
 .table-hover .table-whatsapp:hover > td,
 .table-hover .table-whatsapp:hover > th {
-  background-color: #adefc5;
+  background-color: rgb(172.7424427481, 238.3975572519, 197.268778626);
 }
 
 .table-skype,
 .table-skype > th,
 .table-skype > td {
-  background-color: #b8e9fb;
+  background-color: rgb(183.6, 232.6, 250.8);
 }
 .table-skype th,
 .table-skype td,
 .table-skype thead th,
 .table-skype tbody + tbody {
-  border-color: #7ad5f7;
+  border-color: rgb(122.4, 213.4, 247.2);
 }
 
 .table-hover .table-skype:hover {
-  background-color: #a0e2fa;
+  background-color: rgb(159.5166666667, 225.0444444444, 249.3833333333);
 }
 .table-hover .table-skype:hover > td,
 .table-hover .table-skype:hover > th {
-  background-color: #a0e2fa;
+  background-color: rgb(159.5166666667, 225.0444444444, 249.3833333333);
 }
 
 .table-gray-100,
 .table-gray-100 > th,
 .table-gray-100 > td {
-  background-color: #fdfdfe;
+  background-color: rgb(253.04, 253.32, 253.6);
 }
 .table-gray-100 th,
 .table-gray-100 td,
 .table-gray-100 thead th,
 .table-gray-100 tbody + tbody {
-  border-color: #fbfcfc;
+  border-color: rgb(251.36, 251.88, 252.4);
 }
 
 .table-hover .table-gray-100:hover {
-  background-color: #ececf6;
+  background-color: rgb(238.165, 240.57, 242.975);
 }
 .table-hover .table-gray-100:hover > td,
 .table-hover .table-gray-100:hover > th {
-  background-color: #ececf6;
+  background-color: rgb(238.165, 240.57, 242.975);
 }
 
 .table-gray-200,
 .table-gray-200 > th,
 .table-gray-200 > td {
-  background-color: #f9fafb;
+  background-color: rgb(248.84, 249.68, 250.52);
 }
 .table-gray-200 th,
 .table-gray-200 td,
 .table-gray-200 thead th,
 .table-gray-200 tbody + tbody {
-  border-color: #f4f5f7;
+  border-color: rgb(243.56, 245.12, 246.68);
 }
 
 .table-hover .table-gray-200:hover {
-  background-color: #eaedf1;
+  background-color: rgb(234.0768421053, 236.93, 239.7831578947);
 }
 .table-hover .table-gray-200:hover > td,
 .table-hover .table-gray-200:hover > th {
-  background-color: #eaedf1;
+  background-color: rgb(234.0768421053, 236.93, 239.7831578947);
 }
 
 .table-gray-300,
 .table-gray-300 > th,
 .table-gray-300 > td {
-  background-color: #f6f7f8;
+  background-color: rgb(245.76, 246.88, 248);
 }
 .table-gray-300 th,
 .table-gray-300 td,
 .table-gray-300 thead th,
 .table-gray-300 tbody + tbody {
-  border-color: #eef0f2;
+  border-color: rgb(237.84, 239.92, 242);
 }
 
 .table-hover .table-gray-300:hover {
-  background-color: #e8eaed;
+  background-color: rgb(231.2513793103, 234.13, 237.0086206897);
 }
 .table-hover .table-gray-300:hover > td,
 .table-hover .table-gray-300:hover > th {
-  background-color: #e8eaed;
+  background-color: rgb(231.2513793103, 234.13, 237.0086206897);
 }
 
 .table-gray-400,
 .table-gray-400 > th,
 .table-gray-400 > td {
-  background-color: #f1f3f5;
+  background-color: rgb(241.28, 242.96, 244.64);
 }
 .table-gray-400 th,
 .table-gray-400 td,
 .table-gray-400 thead th,
 .table-gray-400 tbody + tbody {
-  border-color: #e6e9ec;
+  border-color: rgb(229.52, 232.64, 235.76);
 }
 
 .table-hover .table-gray-400:hover {
-  background-color: #e2e6ea;
+  background-color: rgb(226.7509302326, 230.21, 233.6690697674);
 }
 .table-hover .table-gray-400:hover > td,
 .table-hover .table-gray-400:hover > th {
-  background-color: #e2e6ea;
+  background-color: rgb(226.7509302326, 230.21, 233.6690697674);
 }
 
 .table-gray-500,
 .table-gray-500 > th,
 .table-gray-500 > td {
-  background-color: #e8eaed;
+  background-color: rgb(232.04, 234.28, 236.52);
 }
 .table-gray-500 th,
 .table-gray-500 td,
 .table-gray-500 thead th,
 .table-gray-500 tbody + tbody {
-  border-color: #d4d9dd;
+  border-color: rgb(212.36, 216.52, 220.68);
 }
 
 .table-hover .table-gray-500:hover {
-  background-color: #dadde2;
+  background-color: rgb(217.9116216216, 221.53, 225.1483783784);
 }
 .table-hover .table-gray-500:hover > td,
 .table-hover .table-gray-500:hover > th {
-  background-color: #dadde2;
+  background-color: rgb(217.9116216216, 221.53, 225.1483783784);
 }
 
 .table-gray-600,
 .table-gray-600 > th,
 .table-gray-600 > td {
-  background-color: #d6d8db;
+  background-color: rgb(213.84, 216.36, 218.6);
 }
 .table-gray-600 th,
 .table-gray-600 td,
 .table-gray-600 thead th,
 .table-gray-600 tbody + tbody {
-  border-color: #b3b7bb;
+  border-color: rgb(178.56, 183.24, 187.4);
 }
 
 .table-hover .table-gray-600:hover {
-  background-color: #c8cbcf;
+  background-color: rgb(200.3075090253, 203.6560288809, 206.6324909747);
 }
 .table-hover .table-gray-600:hover > td,
 .table-hover .table-gray-600:hover > th {
-  background-color: #c8cbcf;
+  background-color: rgb(200.3075090253, 203.6560288809, 206.6324909747);
 }
 
 .table-gray-700,
 .table-gray-700 > th,
 .table-gray-700 > td {
-  background-color: #ccced0;
+  background-color: rgb(204.04, 206, 207.96);
 }
 .table-gray-700 th,
 .table-gray-700 td,
 .table-gray-700 thead th,
 .table-gray-700 tbody + tbody {
-  border-color: #a0a4a8;
+  border-color: rgb(160.36, 164, 167.64);
 }
 
 .table-hover .table-gray-700:hover {
-  background-color: #bfc1c4;
+  background-color: rgb(190.78, 193.25, 195.72);
 }
 .table-hover .table-gray-700:hover > td,
 .table-hover .table-gray-700:hover > th {
-  background-color: #bfc1c4;
+  background-color: rgb(190.78, 193.25, 195.72);
 }
 
 .table-gray-800,
 .table-gray-800 > th,
 .table-gray-800 > td {
-  background-color: #c6c8ca;
+  background-color: rgb(198.16, 199.84, 201.52);
 }
 .table-gray-800 th,
 .table-gray-800 td,
 .table-gray-800 thead th,
 .table-gray-800 tbody + tbody {
-  border-color: #95999c;
+  border-color: rgb(149.44, 152.56, 155.68);
 }
 
 .table-hover .table-gray-800:hover {
-  background-color: #b9bbbe;
+  background-color: rgb(185.0216751269, 187.09, 189.1583248731);
 }
 .table-hover .table-gray-800:hover > td,
 .table-hover .table-gray-800:hover > th {
-  background-color: #b9bbbe;
+  background-color: rgb(185.0216751269, 187.09, 189.1583248731);
 }
 
 .table-gray-900,
 .table-gray-900 > th,
 .table-gray-900 > td {
-  background-color: #c1c2c3;
+  background-color: rgb(192.84, 193.96, 195.08);
 }
 .table-gray-900 th,
 .table-gray-900 td,
 .table-gray-900 thead th,
 .table-gray-900 tbody + tbody {
-  border-color: #8c8e90;
+  border-color: rgb(139.56, 141.64, 143.72);
 }
 
 .table-hover .table-gray-900:hover {
-  background-color: #b4b5b6;
+  background-color: rgb(179.8560550459, 181.21, 182.5639449541);
 }
 .table-hover .table-gray-900:hover > td,
 .table-hover .table-gray-900:hover > th {
-  background-color: #b4b5b6;
+  background-color: rgb(179.8560550459, 181.21, 182.5639449541);
 }
 
 .table-bootstrap,
 .table-bootstrap > th,
 .table-bootstrap > td {
-  background-color: #d0c9da;
+  background-color: rgb(207.68, 200.68, 218.32);
 }
 .table-bootstrap th,
 .table-bootstrap td,
 .table-bootstrap thead th,
 .table-bootstrap tbody + tbody {
-  border-color: #a79abb;
+  border-color: rgb(167.12, 154.12, 186.88);
 }
 
 .table-hover .table-bootstrap:hover {
-  background-color: #c3bad0;
+  background-color: rgb(194.42, 185.4584615385, 208.0415384615);
 }
 .table-hover .table-bootstrap:hover > td,
 .table-hover .table-bootstrap:hover > th {
-  background-color: #c3bad0;
+  background-color: rgb(194.42, 185.4584615385, 208.0415384615);
 }
 
 .table-active,
@@ -2329,7 +2329,7 @@ pre code {
 .table .thead-dark th {
   color: #fff;
   background-color: #343a40;
-  border-color: #454d55;
+  border-color: rgb(69.1465517241, 77.125, 85.1034482759);
 }
 .table .thead-light th {
   color: #6c757d;
@@ -2344,7 +2344,7 @@ pre code {
 .table-dark th,
 .table-dark td,
 .table-dark thead th {
-  border-color: #454d55;
+  border-color: rgb(69.1465517241, 77.125, 85.1034482759);
 }
 .table-dark.table-bordered {
   border: 0;
@@ -2453,7 +2453,7 @@ pre code {
 .form-control:focus {
   color: #495057;
   background-color: #fff;
-  border-color: #b1dbfe;
+  border-color: rgb(177.2621359223, 219.1796116505, 254.2378640777);
   outline: 0;
   box-shadow: 0 0 0 0.2rem rgba(51, 161, 253, 0.25);
 }
@@ -2681,8 +2681,8 @@ textarea.form-control {
   border-color: #28a745;
 }
 .was-validated .custom-control-input:valid:checked ~ .custom-control-label::before, .custom-control-input.is-valid:checked ~ .custom-control-label::before {
-  border-color: #34ce57;
-  background-color: #34ce57;
+  border-color: rgb(51.6956521739, 206.3043478261, 87);
+  background-color: rgb(51.6956521739, 206.3043478261, 87);
 }
 .was-validated .custom-control-input:valid:focus ~ .custom-control-label::before, .custom-control-input.is-valid:focus ~ .custom-control-label::before {
   box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25);
@@ -2774,8 +2774,8 @@ textarea.form-control {
   border-color: #dc3545;
 }
 .was-validated .custom-control-input:invalid:checked ~ .custom-control-label::before, .custom-control-input.is-invalid:checked ~ .custom-control-label::before {
-  border-color: #e4606d;
-  background-color: #e4606d;
+  border-color: rgb(227.5316455696, 96.4683544304, 109.0253164557);
+  background-color: rgb(227.5316455696, 96.4683544304, 109.0253164557);
 }
 .was-validated .custom-control-input:invalid:focus ~ .custom-control-label::before, .custom-control-input.is-invalid:focus ~ .custom-control-label::before {
   box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);
@@ -2897,14 +2897,14 @@ fieldset:disabled a.btn {
 }
 .btn-primary:hover {
   color: #fff;
-  background-color: #0d90fd;
-  border-color: #028afb;
+  background-color: rgb(13.1213592233, 143.5461165049, 252.6286407767);
+  border-color: rgb(2.4563106796, 137.5533980583, 250.5436893204);
 }
 .btn-primary:focus, .btn-primary.focus {
   color: #fff;
-  background-color: #0d90fd;
-  border-color: #028afb;
-  box-shadow: 0 0 0 0.2rem rgba(82, 175, 253, 0.5);
+  background-color: rgb(13.1213592233, 143.5461165049, 252.6286407767);
+  border-color: rgb(2.4563106796, 137.5533980583, 250.5436893204);
+  box-shadow: 0 0 0 0.2rem rgba(81.6, 175.1, 253.3, 0.5);
 }
 .btn-primary.disabled, .btn-primary:disabled {
   color: #fff;
@@ -2913,11 +2913,11 @@ fieldset:disabled a.btn {
 }
 .btn-primary:not(:disabled):not(.disabled):active, .btn-primary:not(:disabled):not(.disabled).active, .show > .btn-primary.dropdown-toggle {
   color: #fff;
-  background-color: #028afb;
-  border-color: #0283ee;
+  background-color: rgb(2.4563106796, 137.5533980583, 250.5436893204);
+  border-color: rgb(2.3325242718, 130.6213592233, 237.9174757282);
 }
 .btn-primary:not(:disabled):not(.disabled):active:focus, .btn-primary:not(:disabled):not(.disabled).active:focus, .show > .btn-primary.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(82, 175, 253, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(81.6, 175.1, 253.3, 0.5);
 }
 
 .btn-secondary {
@@ -2927,14 +2927,14 @@ fieldset:disabled a.btn {
 }
 .btn-secondary:hover {
   color: #fff;
-  background-color: #282d3a;
-  border-color: #222733;
+  background-color: rgb(39.53125, 45.28125, 58.21875);
+  border-color: rgb(34.375, 39.375, 50.625);
 }
 .btn-secondary:focus, .btn-secondary.focus {
   color: #fff;
-  background-color: #282d3a;
-  border-color: #222733;
-  box-shadow: 0 0 0 0.2rem rgba(85, 92, 107, 0.5);
+  background-color: rgb(39.53125, 45.28125, 58.21875);
+  border-color: rgb(34.375, 39.375, 50.625);
+  box-shadow: 0 0 0 0.2rem rgba(85, 91.8, 107.1, 0.5);
 }
 .btn-secondary.disabled, .btn-secondary:disabled {
   color: #fff;
@@ -2943,11 +2943,11 @@ fieldset:disabled a.btn {
 }
 .btn-secondary:not(:disabled):not(.disabled):active, .btn-secondary:not(:disabled):not(.disabled).active, .show > .btn-secondary.dropdown-toggle {
   color: #fff;
-  background-color: #222733;
-  border-color: #1d212b;
+  background-color: rgb(34.375, 39.375, 50.625);
+  border-color: rgb(29.21875, 33.46875, 43.03125);
 }
 .btn-secondary:not(:disabled):not(.disabled):active:focus, .btn-secondary:not(:disabled):not(.disabled).active:focus, .show > .btn-secondary.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(85, 92, 107, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(85, 91.8, 107.1, 0.5);
 }
 
 .btn-success {
@@ -2957,14 +2957,14 @@ fieldset:disabled a.btn {
 }
 .btn-success:hover {
   color: #fff;
-  background-color: #218838;
-  border-color: #1e7e34;
+  background-color: rgb(32.6086956522, 136.1413043478, 56.25);
+  border-color: rgb(30.1449275362, 125.8550724638, 52);
 }
 .btn-success:focus, .btn-success.focus {
   color: #fff;
-  background-color: #218838;
-  border-color: #1e7e34;
-  box-shadow: 0 0 0 0.2rem rgba(72, 180, 97, 0.5);
+  background-color: rgb(32.6086956522, 136.1413043478, 56.25);
+  border-color: rgb(30.1449275362, 125.8550724638, 52);
+  box-shadow: 0 0 0 0.2rem rgba(72.25, 180.2, 96.9, 0.5);
 }
 .btn-success.disabled, .btn-success:disabled {
   color: #fff;
@@ -2973,11 +2973,11 @@ fieldset:disabled a.btn {
 }
 .btn-success:not(:disabled):not(.disabled):active, .btn-success:not(:disabled):not(.disabled).active, .show > .btn-success.dropdown-toggle {
   color: #fff;
-  background-color: #1e7e34;
-  border-color: #1c7430;
+  background-color: rgb(30.1449275362, 125.8550724638, 52);
+  border-color: rgb(27.6811594203, 115.5688405797, 47.75);
 }
 .btn-success:not(:disabled):not(.disabled):active:focus, .btn-success:not(:disabled):not(.disabled).active:focus, .show > .btn-success.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(72, 180, 97, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(72.25, 180.2, 96.9, 0.5);
 }
 
 .btn-info {
@@ -2987,14 +2987,14 @@ fieldset:disabled a.btn {
 }
 .btn-info:hover {
   color: #fff;
-  background-color: #138496;
-  border-color: #117a8b;
+  background-color: rgb(18.75, 132.0652173913, 150);
+  border-color: rgb(17.3333333333, 122.0869565217, 138.6666666667);
 }
 .btn-info:focus, .btn-info.focus {
   color: #fff;
-  background-color: #138496;
-  border-color: #117a8b;
-  box-shadow: 0 0 0 0.2rem rgba(58, 176, 195, 0.5);
+  background-color: rgb(18.75, 132.0652173913, 150);
+  border-color: rgb(17.3333333333, 122.0869565217, 138.6666666667);
+  box-shadow: 0 0 0 0.2rem rgba(57.8, 175.95, 194.65, 0.5);
 }
 .btn-info.disabled, .btn-info:disabled {
   color: #fff;
@@ -3003,11 +3003,11 @@ fieldset:disabled a.btn {
 }
 .btn-info:not(:disabled):not(.disabled):active, .btn-info:not(:disabled):not(.disabled).active, .show > .btn-info.dropdown-toggle {
   color: #fff;
-  background-color: #117a8b;
-  border-color: #10707f;
+  background-color: rgb(17.3333333333, 122.0869565217, 138.6666666667);
+  border-color: rgb(15.9166666667, 112.1086956522, 127.3333333333);
 }
 .btn-info:not(:disabled):not(.disabled):active:focus, .btn-info:not(:disabled):not(.disabled).active:focus, .show > .btn-info.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(58, 176, 195, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(57.8, 175.95, 194.65, 0.5);
 }
 
 .btn-warning {
@@ -3017,14 +3017,14 @@ fieldset:disabled a.btn {
 }
 .btn-warning:hover {
   color: #212529;
-  background-color: #e0a800;
-  border-color: #d39e00;
+  background-color: rgb(223.75, 167.8125, 0);
+  border-color: rgb(211, 158.25, 0);
 }
 .btn-warning:focus, .btn-warning.focus {
   color: #212529;
-  background-color: #e0a800;
-  border-color: #d39e00;
-  box-shadow: 0 0 0 0.2rem rgba(222, 170, 12, 0.5);
+  background-color: rgb(223.75, 167.8125, 0);
+  border-color: rgb(211, 158.25, 0);
+  box-shadow: 0 0 0 0.2rem rgba(221.7, 169.6, 12.1, 0.5);
 }
 .btn-warning.disabled, .btn-warning:disabled {
   color: #212529;
@@ -3033,11 +3033,11 @@ fieldset:disabled a.btn {
 }
 .btn-warning:not(:disabled):not(.disabled):active, .btn-warning:not(:disabled):not(.disabled).active, .show > .btn-warning.dropdown-toggle {
   color: #212529;
-  background-color: #d39e00;
-  border-color: #c69500;
+  background-color: rgb(211, 158.25, 0);
+  border-color: rgb(198.25, 148.6875, 0);
 }
 .btn-warning:not(:disabled):not(.disabled):active:focus, .btn-warning:not(:disabled):not(.disabled).active:focus, .show > .btn-warning.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(222, 170, 12, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(221.7, 169.6, 12.1, 0.5);
 }
 
 .btn-danger {
@@ -3047,14 +3047,14 @@ fieldset:disabled a.btn {
 }
 .btn-danger:hover {
   color: #fff;
-  background-color: #c82333;
-  border-color: #bd2130;
+  background-color: rgb(200.082278481, 34.667721519, 50.5158227848);
+  border-color: rgb(189.2151898734, 32.7848101266, 47.7721518987);
 }
 .btn-danger:focus, .btn-danger.focus {
   color: #fff;
-  background-color: #c82333;
-  border-color: #bd2130;
-  box-shadow: 0 0 0 0.2rem rgba(225, 83, 97, 0.5);
+  background-color: rgb(200.082278481, 34.667721519, 50.5158227848);
+  border-color: rgb(189.2151898734, 32.7848101266, 47.7721518987);
+  box-shadow: 0 0 0 0.2rem rgba(225.25, 83.3, 96.9, 0.5);
 }
 .btn-danger.disabled, .btn-danger:disabled {
   color: #fff;
@@ -3063,11 +3063,11 @@ fieldset:disabled a.btn {
 }
 .btn-danger:not(:disabled):not(.disabled):active, .btn-danger:not(:disabled):not(.disabled).active, .show > .btn-danger.dropdown-toggle {
   color: #fff;
-  background-color: #bd2130;
-  border-color: #b21f2d;
+  background-color: rgb(189.2151898734, 32.7848101266, 47.7721518987);
+  border-color: rgb(178.3481012658, 30.9018987342, 45.0284810127);
 }
 .btn-danger:not(:disabled):not(.disabled):active:focus, .btn-danger:not(:disabled):not(.disabled).active:focus, .show > .btn-danger.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(225, 83, 97, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(225.25, 83.3, 96.9, 0.5);
 }
 
 .btn-light {
@@ -3077,14 +3077,14 @@ fieldset:disabled a.btn {
 }
 .btn-light:hover {
   color: #212529;
-  background-color: #e2e6ea;
-  border-color: #dae0e5;
+  background-color: rgb(225.6875, 229.875, 234.0625);
+  border-color: rgb(218.25, 223.5, 228.75);
 }
 .btn-light:focus, .btn-light.focus {
   color: #212529;
-  background-color: #e2e6ea;
-  border-color: #dae0e5;
-  box-shadow: 0 0 0 0.2rem rgba(216, 217, 219, 0.5);
+  background-color: rgb(225.6875, 229.875, 234.0625);
+  border-color: rgb(218.25, 223.5, 228.75);
+  box-shadow: 0 0 0 0.2rem rgba(215.75, 217.2, 218.65, 0.5);
 }
 .btn-light.disabled, .btn-light:disabled {
   color: #212529;
@@ -3093,11 +3093,11 @@ fieldset:disabled a.btn {
 }
 .btn-light:not(:disabled):not(.disabled):active, .btn-light:not(:disabled):not(.disabled).active, .show > .btn-light.dropdown-toggle {
   color: #212529;
-  background-color: #dae0e5;
-  border-color: #d3d9df;
+  background-color: rgb(218.25, 223.5, 228.75);
+  border-color: rgb(210.8125, 217.125, 223.4375);
 }
 .btn-light:not(:disabled):not(.disabled):active:focus, .btn-light:not(:disabled):not(.disabled).active:focus, .show > .btn-light.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(216, 217, 219, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(215.75, 217.2, 218.65, 0.5);
 }
 
 .btn-dark {
@@ -3107,14 +3107,14 @@ fieldset:disabled a.btn {
 }
 .btn-dark:hover {
   color: #fff;
-  background-color: #23272b;
-  border-color: #1d2124;
+  background-color: rgb(34.8534482759, 38.875, 42.8965517241);
+  border-color: rgb(29.1379310345, 32.5, 35.8620689655);
 }
 .btn-dark:focus, .btn-dark.focus {
   color: #fff;
-  background-color: #23272b;
-  border-color: #1d2124;
-  box-shadow: 0 0 0 0.2rem rgba(82, 88, 93, 0.5);
+  background-color: rgb(34.8534482759, 38.875, 42.8965517241);
+  border-color: rgb(29.1379310345, 32.5, 35.8620689655);
+  box-shadow: 0 0 0 0.2rem rgba(82.45, 87.55, 92.65, 0.5);
 }
 .btn-dark.disabled, .btn-dark:disabled {
   color: #fff;
@@ -3123,11 +3123,11 @@ fieldset:disabled a.btn {
 }
 .btn-dark:not(:disabled):not(.disabled):active, .btn-dark:not(:disabled):not(.disabled).active, .show > .btn-dark.dropdown-toggle {
   color: #fff;
-  background-color: #1d2124;
-  border-color: #171a1d;
+  background-color: rgb(29.1379310345, 32.5, 35.8620689655);
+  border-color: rgb(23.4224137931, 26.125, 28.8275862069);
 }
 .btn-dark:not(:disabled):not(.disabled):active:focus, .btn-dark:not(:disabled):not(.disabled).active:focus, .show > .btn-dark.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(82, 88, 93, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(82.45, 87.55, 92.65, 0.5);
 }
 
 .btn-black {
@@ -3144,7 +3144,7 @@ fieldset:disabled a.btn {
   color: #fff;
   background-color: black;
   border-color: black;
-  box-shadow: 0 0 0 0.2rem rgba(38, 38, 38, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(38.25, 38.25, 38.25, 0.5);
 }
 .btn-black.disabled, .btn-black:disabled {
   color: #fff;
@@ -3157,7 +3157,7 @@ fieldset:disabled a.btn {
   border-color: black;
 }
 .btn-black:not(:disabled):not(.disabled):active:focus, .btn-black:not(:disabled):not(.disabled).active:focus, .show > .btn-black.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(38, 38, 38, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(38.25, 38.25, 38.25, 0.5);
 }
 
 .btn-instagram {
@@ -3167,14 +3167,14 @@ fieldset:disabled a.btn {
 }
 .btn-instagram:hover {
   color: #fff;
-  background-color: #de1f44;
-  border-color: #d31e40;
+  background-color: rgb(222.3222477064, 31.4277522936, 67.5114678899);
+  border-color: rgb(211.1513761468, 29.8486238532, 64.119266055);
 }
 .btn-instagram:focus, .btn-instagram.focus {
   color: #fff;
-  background-color: #de1f44;
-  border-color: #d31e40;
-  box-shadow: 0 0 0 0.2rem rgba(232, 93, 119, 0.5);
+  background-color: rgb(222.3222477064, 31.4277522936, 67.5114678899);
+  border-color: rgb(211.1513761468, 29.8486238532, 64.119266055);
+  box-shadow: 0 0 0 0.2rem rgba(232.05, 92.65, 119, 0.5);
 }
 .btn-instagram.disabled, .btn-instagram:disabled {
   color: #fff;
@@ -3183,11 +3183,11 @@ fieldset:disabled a.btn {
 }
 .btn-instagram:not(:disabled):not(.disabled):active, .btn-instagram:not(:disabled):not(.disabled).active, .show > .btn-instagram.dropdown-toggle {
   color: #fff;
-  background-color: #d31e40;
-  border-color: #c81c3d;
+  background-color: rgb(211.1513761468, 29.8486238532, 64.119266055);
+  border-color: rgb(199.9805045872, 28.2694954128, 60.7270642202);
 }
 .btn-instagram:not(:disabled):not(.disabled):active:focus, .btn-instagram:not(:disabled):not(.disabled).active:focus, .show > .btn-instagram.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(232, 93, 119, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(232.05, 92.65, 119, 0.5);
 }
 
 .btn-facebook {
@@ -3197,14 +3197,14 @@ fieldset:disabled a.btn {
 }
 .btn-facebook:hover {
   color: #fff;
-  background-color: #30497d;
-  border-color: #2d4474;
+  background-color: rgb(48.3549528302, 72.9422169811, 125.3950471698);
+  border-color: rgb(44.8066037736, 67.5896226415, 116.1933962264);
 }
 .btn-facebook:focus, .btn-facebook.focus {
   color: #fff;
-  background-color: #30497d;
-  border-color: #2d4474;
-  box-shadow: 0 0 0 0.2rem rgba(88, 114, 168, 0.5);
+  background-color: rgb(48.3549528302, 72.9422169811, 125.3950471698);
+  border-color: rgb(44.8066037736, 67.5896226415, 116.1933962264);
+  box-shadow: 0 0 0 0.2rem rgba(88.4, 113.9, 168.3, 0.5);
 }
 .btn-facebook.disabled, .btn-facebook:disabled {
   color: #fff;
@@ -3213,11 +3213,11 @@ fieldset:disabled a.btn {
 }
 .btn-facebook:not(:disabled):not(.disabled):active, .btn-facebook:not(:disabled):not(.disabled).active, .show > .btn-facebook.dropdown-toggle {
   color: #fff;
-  background-color: #2d4474;
-  border-color: #293e6b;
+  background-color: rgb(44.8066037736, 67.5896226415, 116.1933962264);
+  border-color: rgb(41.258254717, 62.2370283019, 106.991745283);
 }
 .btn-facebook:not(:disabled):not(.disabled):active:focus, .btn-facebook:not(:disabled):not(.disabled).active:focus, .show > .btn-facebook.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(88, 114, 168, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(88.4, 113.9, 168.3, 0.5);
 }
 
 .btn-messenger {
@@ -3227,14 +3227,14 @@ fieldset:disabled a.btn {
 }
 .btn-messenger:hover {
   color: #fff;
-  background-color: #0070d9;
-  border-color: #006acc;
+  background-color: rgb(0, 112.2, 216.75);
+  border-color: rgb(0, 105.6, 204);
 }
 .btn-messenger:focus, .btn-messenger.focus {
   color: #fff;
-  background-color: #0070d9;
-  border-color: #006acc;
-  box-shadow: 0 0 0 0.2rem rgba(38, 150, 255, 0.5);
+  background-color: rgb(0, 112.2, 216.75);
+  border-color: rgb(0, 105.6, 204);
+  box-shadow: 0 0 0 0.2rem rgba(38.25, 150.45, 255, 0.5);
 }
 .btn-messenger.disabled, .btn-messenger:disabled {
   color: #fff;
@@ -3243,11 +3243,11 @@ fieldset:disabled a.btn {
 }
 .btn-messenger:not(:disabled):not(.disabled):active, .btn-messenger:not(:disabled):not(.disabled).active, .show > .btn-messenger.dropdown-toggle {
   color: #fff;
-  background-color: #006acc;
-  border-color: #0063bf;
+  background-color: rgb(0, 105.6, 204);
+  border-color: rgb(0, 99, 191.25);
 }
 .btn-messenger:not(:disabled):not(.disabled):active:focus, .btn-messenger:not(:disabled):not(.disabled).active:focus, .show > .btn-messenger.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(38, 150, 255, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(38.25, 150.45, 255, 0.5);
 }
 
 .btn-youtube {
@@ -3257,14 +3257,14 @@ fieldset:disabled a.btn {
 }
 .btn-youtube:hover {
   color: #fff;
-  background-color: #ac1b1a;
-  border-color: #a11918;
+  background-color: rgb(171.7743644068, 26.813559322, 25.9756355932);
+  border-color: rgb(160.6991525424, 25.0847457627, 24.3008474576);
 }
 .btn-youtube:focus, .btn-youtube.focus {
   color: #fff;
-  background-color: #ac1b1a;
-  border-color: #a11918;
-  box-shadow: 0 0 0 0.2rem rgba(213, 65, 65, 0.5);
+  background-color: rgb(171.7743644068, 26.813559322, 25.9756355932);
+  border-color: rgb(160.6991525424, 25.0847457627, 24.3008474576);
+  box-shadow: 0 0 0 0.2rem rgba(212.5, 65.45, 64.6, 0.5);
 }
 .btn-youtube.disabled, .btn-youtube:disabled {
   color: #fff;
@@ -3273,11 +3273,11 @@ fieldset:disabled a.btn {
 }
 .btn-youtube:not(:disabled):not(.disabled):active, .btn-youtube:not(:disabled):not(.disabled).active, .show > .btn-youtube.dropdown-toggle {
   color: #fff;
-  background-color: #a11918;
-  border-color: #961717;
+  background-color: rgb(160.6991525424, 25.0847457627, 24.3008474576);
+  border-color: rgb(149.623940678, 23.3559322034, 22.626059322);
 }
 .btn-youtube:not(:disabled):not(.disabled):active:focus, .btn-youtube:not(:disabled):not(.disabled).active:focus, .show > .btn-youtube.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(213, 65, 65, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(212.5, 65.45, 64.6, 0.5);
 }
 
 .btn-twitter {
@@ -3287,14 +3287,14 @@ fieldset:disabled a.btn {
 }
 .btn-twitter:hover {
   color: #fff;
-  background-color: #329beb;
-  border-color: #2795e9;
+  background-color: rgb(50.2272727273, 155.0227272727, 234.5227272727);
+  border-color: rgb(38.6363636364, 149.3636363636, 233.3636363636);
 }
 .btn-twitter:focus, .btn-twitter.focus {
   color: #fff;
-  background-color: #329beb;
-  border-color: #2795e9;
-  box-shadow: 0 0 0 0.2rem rgba(77, 152, 208, 0.5);
+  background-color: rgb(50.2272727273, 155.0227272727, 234.5227272727);
+  border-color: rgb(38.6363636364, 149.3636363636, 233.3636363636);
+  box-shadow: 0 0 0 0.2rem rgba(77.2, 151.75, 208.45, 0.5);
 }
 .btn-twitter.disabled, .btn-twitter:disabled {
   color: #212529;
@@ -3303,11 +3303,11 @@ fieldset:disabled a.btn {
 }
 .btn-twitter:not(:disabled):not(.disabled):active, .btn-twitter:not(:disabled):not(.disabled).active, .show > .btn-twitter.dropdown-toggle {
   color: #fff;
-  background-color: #2795e9;
-  border-color: #1b90e8;
+  background-color: rgb(38.6363636364, 149.3636363636, 233.3636363636);
+  border-color: rgb(27.0454545455, 143.7045454545, 232.2045454545);
 }
 .btn-twitter:not(:disabled):not(.disabled):active:focus, .btn-twitter:not(:disabled):not(.disabled).active:focus, .show > .btn-twitter.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(77, 152, 208, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(77.2, 151.75, 208.45, 0.5);
 }
 
 .btn-linkedin {
@@ -3317,14 +3317,14 @@ fieldset:disabled a.btn {
 }
 .btn-linkedin:hover {
   color: #fff;
-  background-color: #005e8f;
-  border-color: #005582;
+  background-color: rgb(0, 93.8522099448, 142.75);
+  border-color: rgb(0, 85.4696132597, 130);
 }
 .btn-linkedin:focus, .btn-linkedin.focus {
   color: #fff;
-  background-color: #005e8f;
-  border-color: #005582;
-  box-shadow: 0 0 0 0.2rem rgba(38, 139, 192, 0.5);
+  background-color: rgb(0, 93.8522099448, 142.75);
+  border-color: rgb(0, 85.4696132597, 130);
+  box-shadow: 0 0 0 0.2rem rgba(38.25, 139.4, 192.1, 0.5);
 }
 .btn-linkedin.disabled, .btn-linkedin:disabled {
   color: #fff;
@@ -3333,11 +3333,11 @@ fieldset:disabled a.btn {
 }
 .btn-linkedin:not(:disabled):not(.disabled):active, .btn-linkedin:not(:disabled):not(.disabled).active, .show > .btn-linkedin.dropdown-toggle {
   color: #fff;
-  background-color: #005582;
-  border-color: #004d75;
+  background-color: rgb(0, 85.4696132597, 130);
+  border-color: rgb(0, 77.0870165746, 117.25);
 }
 .btn-linkedin:not(:disabled):not(.disabled):active:focus, .btn-linkedin:not(:disabled):not(.disabled).active:focus, .show > .btn-linkedin.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(38, 139, 192, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(38.25, 139.4, 192.1, 0.5);
 }
 
 .btn-snapchat {
@@ -3347,14 +3347,14 @@ fieldset:disabled a.btn {
 }
 .btn-snapchat:hover {
   color: #212529;
-  background-color: #d9d600;
-  border-color: #ccca00;
+  background-color: rgb(216.75, 214.2, 0);
+  border-color: rgb(204, 201.6, 0);
 }
 .btn-snapchat:focus, .btn-snapchat.focus {
   color: #212529;
-  background-color: #d9d600;
-  border-color: #ccca00;
-  box-shadow: 0 0 0 0.2rem rgba(222, 220, 6, 0.5);
+  background-color: rgb(216.75, 214.2, 0);
+  border-color: rgb(204, 201.6, 0);
+  box-shadow: 0 0 0 0.2rem rgba(221.7, 219.75, 6.15, 0.5);
 }
 .btn-snapchat.disabled, .btn-snapchat:disabled {
   color: #212529;
@@ -3363,11 +3363,11 @@ fieldset:disabled a.btn {
 }
 .btn-snapchat:not(:disabled):not(.disabled):active, .btn-snapchat:not(:disabled):not(.disabled).active, .show > .btn-snapchat.dropdown-toggle {
   color: #212529;
-  background-color: #ccca00;
-  border-color: #bfbd00;
+  background-color: rgb(204, 201.6, 0);
+  border-color: rgb(191.25, 189, 0);
 }
 .btn-snapchat:not(:disabled):not(.disabled):active:focus, .btn-snapchat:not(:disabled):not(.disabled).active:focus, .show > .btn-snapchat.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(222, 220, 6, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(221.7, 219.75, 6.15, 0.5);
 }
 
 .btn-whatsapp {
@@ -3377,14 +3377,14 @@ fieldset:disabled a.btn {
 }
 .btn-whatsapp:hover {
   color: #fff;
-  background-color: #1fb256;
-  border-color: #1da851;
+  background-color: rgb(31.2933467742, 178.4566532258, 86.2681451613);
+  border-color: rgb(29.3911290323, 167.6088709677, 81.0241935484);
 }
 .btn-whatsapp:focus, .btn-whatsapp.focus {
   color: #fff;
-  background-color: #1fb256;
-  border-color: #1da851;
-  box-shadow: 0 0 0 0.2rem rgba(70, 218, 125, 0.5);
+  background-color: rgb(31.2933467742, 178.4566532258, 86.2681451613);
+  border-color: rgb(29.3911290323, 167.6088709677, 81.0241935484);
+  box-shadow: 0 0 0 0.2rem rgba(69.7, 217.6, 124.95, 0.5);
 }
 .btn-whatsapp.disabled, .btn-whatsapp:disabled {
   color: #fff;
@@ -3393,11 +3393,11 @@ fieldset:disabled a.btn {
 }
 .btn-whatsapp:not(:disabled):not(.disabled):active, .btn-whatsapp:not(:disabled):not(.disabled).active, .show > .btn-whatsapp.dropdown-toggle {
   color: #fff;
-  background-color: #1da851;
-  border-color: #1b9d4c;
+  background-color: rgb(29.3911290323, 167.6088709677, 81.0241935484);
+  border-color: rgb(27.4889112903, 156.7610887097, 75.7802419355);
 }
 .btn-whatsapp:not(:disabled):not(.disabled):active:focus, .btn-whatsapp:not(:disabled):not(.disabled).active:focus, .show > .btn-whatsapp.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(70, 218, 125, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(69.7, 217.6, 124.95, 0.5);
 }
 
 .btn-skype {
@@ -3407,14 +3407,14 @@ fieldset:disabled a.btn {
 }
 .btn-skype:hover {
   color: #fff;
-  background-color: #0093ca;
-  border-color: #008abd;
+  background-color: rgb(0, 147.109375, 201.75);
+  border-color: rgb(0, 137.8125, 189);
 }
 .btn-skype:focus, .btn-skype.focus {
   color: #fff;
-  background-color: #0093ca;
-  border-color: #008abd;
-  box-shadow: 0 0 0 0.2rem rgba(38, 187, 242, 0.5);
+  background-color: rgb(0, 147.109375, 201.75);
+  border-color: rgb(0, 137.8125, 189);
+  box-shadow: 0 0 0 0.2rem rgba(38.25, 187, 242.25, 0.5);
 }
 .btn-skype.disabled, .btn-skype:disabled {
   color: #fff;
@@ -3423,11 +3423,11 @@ fieldset:disabled a.btn {
 }
 .btn-skype:not(:disabled):not(.disabled):active, .btn-skype:not(:disabled):not(.disabled).active, .show > .btn-skype.dropdown-toggle {
   color: #fff;
-  background-color: #008abd;
-  border-color: #0081b0;
+  background-color: rgb(0, 137.8125, 189);
+  border-color: rgb(0, 128.515625, 176.25);
 }
 .btn-skype:not(:disabled):not(.disabled):active:focus, .btn-skype:not(:disabled):not(.disabled).active:focus, .show > .btn-skype.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(38, 187, 242, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(38.25, 187, 242.25, 0.5);
 }
 
 .btn-gray-100 {
@@ -3437,14 +3437,14 @@ fieldset:disabled a.btn {
 }
 .btn-gray-100:hover {
   color: #212529;
-  background-color: #e2e6ea;
-  border-color: #dae0e5;
+  background-color: rgb(225.6875, 229.875, 234.0625);
+  border-color: rgb(218.25, 223.5, 228.75);
 }
 .btn-gray-100:focus, .btn-gray-100.focus {
   color: #212529;
-  background-color: #e2e6ea;
-  border-color: #dae0e5;
-  box-shadow: 0 0 0 0.2rem rgba(216, 217, 219, 0.5);
+  background-color: rgb(225.6875, 229.875, 234.0625);
+  border-color: rgb(218.25, 223.5, 228.75);
+  box-shadow: 0 0 0 0.2rem rgba(215.75, 217.2, 218.65, 0.5);
 }
 .btn-gray-100.disabled, .btn-gray-100:disabled {
   color: #212529;
@@ -3453,11 +3453,11 @@ fieldset:disabled a.btn {
 }
 .btn-gray-100:not(:disabled):not(.disabled):active, .btn-gray-100:not(:disabled):not(.disabled).active, .show > .btn-gray-100.dropdown-toggle {
   color: #212529;
-  background-color: #dae0e5;
-  border-color: #d3d9df;
+  background-color: rgb(218.25, 223.5, 228.75);
+  border-color: rgb(210.8125, 217.125, 223.4375);
 }
 .btn-gray-100:not(:disabled):not(.disabled):active:focus, .btn-gray-100:not(:disabled):not(.disabled).active:focus, .show > .btn-gray-100.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(216, 217, 219, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(215.75, 217.2, 218.65, 0.5);
 }
 
 .btn-gray-200 {
@@ -3467,14 +3467,14 @@ fieldset:disabled a.btn {
 }
 .btn-gray-200:hover {
   color: #212529;
-  background-color: #d3d9df;
-  border-color: #cbd3da;
+  background-color: rgb(210.8552631579, 216.875, 222.8947368421);
+  border-color: rgb(203.4736842105, 210.5, 217.5263157895);
 }
 .btn-gray-200:focus, .btn-gray-200.focus {
   color: #212529;
-  background-color: #d3d9df;
-  border-color: #cbd3da;
-  box-shadow: 0 0 0 0.2rem rgba(203, 206, 209, 0.5);
+  background-color: rgb(210.8552631579, 216.875, 222.8947368421);
+  border-color: rgb(203.4736842105, 210.5, 217.5263157895);
+  box-shadow: 0 0 0 0.2rem rgba(203, 206.15, 209.3, 0.5);
 }
 .btn-gray-200.disabled, .btn-gray-200:disabled {
   color: #212529;
@@ -3483,11 +3483,11 @@ fieldset:disabled a.btn {
 }
 .btn-gray-200:not(:disabled):not(.disabled):active, .btn-gray-200:not(:disabled):not(.disabled).active, .show > .btn-gray-200.dropdown-toggle {
   color: #212529;
-  background-color: #cbd3da;
-  border-color: #c4ccd4;
+  background-color: rgb(203.4736842105, 210.5, 217.5263157895);
+  border-color: rgb(196.0921052632, 204.125, 212.1578947368);
 }
 .btn-gray-200:not(:disabled):not(.disabled):active:focus, .btn-gray-200:not(:disabled):not(.disabled).active:focus, .show > .btn-gray-200.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(203, 206, 209, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(203, 206.15, 209.3, 0.5);
 }
 
 .btn-gray-300 {
@@ -3497,14 +3497,14 @@ fieldset:disabled a.btn {
 }
 .btn-gray-300:hover {
   color: #212529;
-  background-color: #c8cfd6;
-  border-color: #c1c9d0;
+  background-color: rgb(200.2370689655, 206.875, 213.5129310345);
+  border-color: rgb(192.9827586207, 200.5, 208.0172413793);
 }
 .btn-gray-300:focus, .btn-gray-300.focus {
   color: #212529;
-  background-color: #c8cfd6;
-  border-color: #c1c9d0;
-  box-shadow: 0 0 0 0.2rem rgba(194, 198, 202, 0.5);
+  background-color: rgb(200.2370689655, 206.875, 213.5129310345);
+  border-color: rgb(192.9827586207, 200.5, 208.0172413793);
+  box-shadow: 0 0 0 0.2rem rgba(193.65, 197.65, 201.65, 0.5);
 }
 .btn-gray-300.disabled, .btn-gray-300:disabled {
   color: #212529;
@@ -3513,11 +3513,11 @@ fieldset:disabled a.btn {
 }
 .btn-gray-300:not(:disabled):not(.disabled):active, .btn-gray-300:not(:disabled):not(.disabled).active, .show > .btn-gray-300.dropdown-toggle {
   color: #212529;
-  background-color: #c1c9d0;
-  border-color: #bac2cb;
+  background-color: rgb(192.9827586207, 200.5, 208.0172413793);
+  border-color: rgb(185.7284482759, 194.125, 202.5215517241);
 }
 .btn-gray-300:not(:disabled):not(.disabled):active:focus, .btn-gray-300:not(:disabled):not(.disabled).active:focus, .show > .btn-gray-300.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(194, 198, 202, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(193.65, 197.65, 201.65, 0.5);
 }
 
 .btn-gray-400 {
@@ -3527,14 +3527,14 @@ fieldset:disabled a.btn {
 }
 .btn-gray-400:hover {
   color: #212529;
-  background-color: #b8c1ca;
-  border-color: #b1bbc4;
+  background-color: rgb(184.2063953488, 192.875, 201.5436046512);
+  border-color: rgb(176.9418604651, 186.5, 196.0581395349);
 }
 .btn-gray-400:focus, .btn-gray-400.focus {
   color: #212529;
-  background-color: #b8c1ca;
-  border-color: #b1bbc4;
-  box-shadow: 0 0 0 0.2rem rgba(180, 186, 191, 0.5);
+  background-color: rgb(184.2063953488, 192.875, 201.5436046512);
+  border-color: rgb(176.9418604651, 186.5, 196.0581395349);
+  box-shadow: 0 0 0 0.2rem rgba(180.05, 185.75, 191.45, 0.5);
 }
 .btn-gray-400.disabled, .btn-gray-400:disabled {
   color: #212529;
@@ -3543,11 +3543,11 @@ fieldset:disabled a.btn {
 }
 .btn-gray-400:not(:disabled):not(.disabled):active, .btn-gray-400:not(:disabled):not(.disabled).active, .show > .btn-gray-400.dropdown-toggle {
   color: #212529;
-  background-color: #b1bbc4;
-  border-color: #aab4bf;
+  background-color: rgb(176.9418604651, 186.5, 196.0581395349);
+  border-color: rgb(169.6773255814, 180.125, 190.5726744186);
 }
 .btn-gray-400:not(:disabled):not(.disabled):active:focus, .btn-gray-400:not(:disabled):not(.disabled).active:focus, .show > .btn-gray-400.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(180, 186, 191, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(180.05, 185.75, 191.45, 0.5);
 }
 
 .btn-gray-500 {
@@ -3557,14 +3557,14 @@ fieldset:disabled a.btn {
 }
 .btn-gray-500:hover {
   color: #212529;
-  background-color: #98a2ac;
-  border-color: #919ca6;
+  background-color: rgb(151.8074324324, 161.875, 171.9425675676);
+  border-color: rgb(144.7432432432, 155.5, 166.2567567568);
 }
 .btn-gray-500:focus, .btn-gray-500.focus {
   color: #212529;
-  background-color: #98a2ac;
-  border-color: #919ca6;
-  box-shadow: 0 0 0 0.2rem rgba(152, 159, 167, 0.5);
+  background-color: rgb(151.8074324324, 161.875, 171.9425675676);
+  border-color: rgb(144.7432432432, 155.5, 166.2567567568);
+  box-shadow: 0 0 0 0.2rem rgba(152, 159.4, 166.8, 0.5);
 }
 .btn-gray-500.disabled, .btn-gray-500:disabled {
   color: #212529;
@@ -3573,11 +3573,11 @@ fieldset:disabled a.btn {
 }
 .btn-gray-500:not(:disabled):not(.disabled):active, .btn-gray-500:not(:disabled):not(.disabled).active, .show > .btn-gray-500.dropdown-toggle {
   color: #212529;
-  background-color: #919ca6;
-  border-color: #8a95a1;
+  background-color: rgb(144.7432432432, 155.5, 166.2567567568);
+  border-color: rgb(137.6790540541, 149.125, 160.5709459459);
 }
 .btn-gray-500:not(:disabled):not(.disabled):active:focus, .btn-gray-500:not(:disabled):not(.disabled).active:focus, .show > .btn-gray-500.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(152, 159, 167, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(152, 159.4, 166.8, 0.5);
 }
 
 .btn-gray-600 {
@@ -3587,14 +3587,14 @@ fieldset:disabled a.btn {
 }
 .btn-gray-600:hover {
   color: #fff;
-  background-color: #5a6268;
-  border-color: #545b62;
+  background-color: rgb(90.2703862661, 97.7929184549, 104.4796137339);
+  border-color: rgb(84.3605150215, 91.3905579399, 97.6394849785);
 }
 .btn-gray-600:focus, .btn-gray-600.focus {
   color: #fff;
-  background-color: #5a6268;
-  border-color: #545b62;
-  box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.5);
+  background-color: rgb(90.2703862661, 97.7929184549, 104.4796137339);
+  border-color: rgb(84.3605150215, 91.3905579399, 97.6394849785);
+  box-shadow: 0 0 0 0.2rem rgba(130.05, 137.7, 144.5, 0.5);
 }
 .btn-gray-600.disabled, .btn-gray-600:disabled {
   color: #fff;
@@ -3603,11 +3603,11 @@ fieldset:disabled a.btn {
 }
 .btn-gray-600:not(:disabled):not(.disabled):active, .btn-gray-600:not(:disabled):not(.disabled).active, .show > .btn-gray-600.dropdown-toggle {
   color: #fff;
-  background-color: #545b62;
-  border-color: #4e555b;
+  background-color: rgb(84.3605150215, 91.3905579399, 97.6394849785);
+  border-color: rgb(78.4506437768, 84.9881974249, 90.7993562232);
 }
 .btn-gray-600:not(:disabled):not(.disabled):active:focus, .btn-gray-600:not(:disabled):not(.disabled).active:focus, .show > .btn-gray-600.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(130.05, 137.7, 144.5, 0.5);
 }
 
 .btn-gray-700 {
@@ -3617,14 +3617,14 @@ fieldset:disabled a.btn {
 }
 .btn-gray-700:hover {
   color: #fff;
-  background-color: #383d42;
-  border-color: #32373b;
+  background-color: rgb(55.5484375, 60.875, 66.2015625);
+  border-color: rgb(49.73125, 54.5, 59.26875);
 }
 .btn-gray-700:focus, .btn-gray-700.focus {
   color: #fff;
-  background-color: #383d42;
-  border-color: #32373b;
-  box-shadow: 0 0 0 0.2rem rgba(100, 106, 112, 0.5);
+  background-color: rgb(55.5484375, 60.875, 66.2015625);
+  border-color: rgb(49.73125, 54.5, 59.26875);
+  box-shadow: 0 0 0 0.2rem rgba(100.3, 106.25, 112.2, 0.5);
 }
 .btn-gray-700.disabled, .btn-gray-700:disabled {
   color: #fff;
@@ -3633,11 +3633,11 @@ fieldset:disabled a.btn {
 }
 .btn-gray-700:not(:disabled):not(.disabled):active, .btn-gray-700:not(:disabled):not(.disabled).active, .show > .btn-gray-700.dropdown-toggle {
   color: #fff;
-  background-color: #32373b;
-  border-color: #2c3034;
+  background-color: rgb(49.73125, 54.5, 59.26875);
+  border-color: rgb(43.9140625, 48.125, 52.3359375);
 }
 .btn-gray-700:not(:disabled):not(.disabled):active:focus, .btn-gray-700:not(:disabled):not(.disabled).active:focus, .show > .btn-gray-700.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(100, 106, 112, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(100.3, 106.25, 112.2, 0.5);
 }
 
 .btn-gray-800 {
@@ -3647,14 +3647,14 @@ fieldset:disabled a.btn {
 }
 .btn-gray-800:hover {
   color: #fff;
-  background-color: #23272b;
-  border-color: #1d2124;
+  background-color: rgb(34.8534482759, 38.875, 42.8965517241);
+  border-color: rgb(29.1379310345, 32.5, 35.8620689655);
 }
 .btn-gray-800:focus, .btn-gray-800.focus {
   color: #fff;
-  background-color: #23272b;
-  border-color: #1d2124;
-  box-shadow: 0 0 0 0.2rem rgba(82, 88, 93, 0.5);
+  background-color: rgb(34.8534482759, 38.875, 42.8965517241);
+  border-color: rgb(29.1379310345, 32.5, 35.8620689655);
+  box-shadow: 0 0 0 0.2rem rgba(82.45, 87.55, 92.65, 0.5);
 }
 .btn-gray-800.disabled, .btn-gray-800:disabled {
   color: #fff;
@@ -3663,11 +3663,11 @@ fieldset:disabled a.btn {
 }
 .btn-gray-800:not(:disabled):not(.disabled):active, .btn-gray-800:not(:disabled):not(.disabled).active, .show > .btn-gray-800.dropdown-toggle {
   color: #fff;
-  background-color: #1d2124;
-  border-color: #171a1d;
+  background-color: rgb(29.1379310345, 32.5, 35.8620689655);
+  border-color: rgb(23.4224137931, 26.125, 28.8275862069);
 }
 .btn-gray-800:not(:disabled):not(.disabled):active:focus, .btn-gray-800:not(:disabled):not(.disabled).active:focus, .show > .btn-gray-800.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(82, 88, 93, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(82.45, 87.55, 92.65, 0.5);
 }
 
 .btn-gray-900 {
@@ -3677,14 +3677,14 @@ fieldset:disabled a.btn {
 }
 .btn-gray-900:hover {
   color: #fff;
-  background-color: #101214;
-  border-color: #0a0c0d;
+  background-color: rgb(15.9425675676, 17.875, 19.8074324324);
+  border-color: rgb(10.2567567568, 11.5, 12.7432432432);
 }
 .btn-gray-900:focus, .btn-gray-900.focus {
   color: #fff;
-  background-color: #101214;
-  border-color: #0a0c0d;
-  box-shadow: 0 0 0 0.2rem rgba(66, 70, 73, 0.5);
+  background-color: rgb(15.9425675676, 17.875, 19.8074324324);
+  border-color: rgb(10.2567567568, 11.5, 12.7432432432);
+  box-shadow: 0 0 0 0.2rem rgba(66.3, 69.7, 73.1, 0.5);
 }
 .btn-gray-900.disabled, .btn-gray-900:disabled {
   color: #fff;
@@ -3693,11 +3693,11 @@ fieldset:disabled a.btn {
 }
 .btn-gray-900:not(:disabled):not(.disabled):active, .btn-gray-900:not(:disabled):not(.disabled).active, .show > .btn-gray-900.dropdown-toggle {
   color: #fff;
-  background-color: #0a0c0d;
-  border-color: #050506;
+  background-color: rgb(10.2567567568, 11.5, 12.7432432432);
+  border-color: rgb(4.5709459459, 5.125, 5.6790540541);
 }
 .btn-gray-900:not(:disabled):not(.disabled):active:focus, .btn-gray-900:not(:disabled):not(.disabled).active:focus, .show > .btn-gray-900.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(66, 70, 73, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(66.3, 69.7, 73.1, 0.5);
 }
 
 .btn-bootstrap {
@@ -3707,14 +3707,14 @@ fieldset:disabled a.btn {
 }
 .btn-bootstrap:hover {
   color: #fff;
-  background-color: #443062;
-  border-color: #3e2c5a;
+  background-color: rgb(68.2189189189, 48.3878378378, 98.3621621622);
+  border-color: rgb(62.2918918919, 44.1837837838, 89.8162162162);
 }
 .btn-bootstrap:focus, .btn-bootstrap.focus {
   color: #fff;
-  background-color: #443062;
-  border-color: #3e2c5a;
-  box-shadow: 0 0 0 0.2rem rgba(111, 90, 144, 0.5);
+  background-color: rgb(68.2189189189, 48.3878378378, 98.3621621622);
+  border-color: rgb(62.2918918919, 44.1837837838, 89.8162162162);
+  box-shadow: 0 0 0 0.2rem rgba(111.35, 90.1, 143.65, 0.5);
 }
 .btn-bootstrap.disabled, .btn-bootstrap:disabled {
   color: #fff;
@@ -3723,11 +3723,11 @@ fieldset:disabled a.btn {
 }
 .btn-bootstrap:not(:disabled):not(.disabled):active, .btn-bootstrap:not(:disabled):not(.disabled).active, .show > .btn-bootstrap.dropdown-toggle {
   color: #fff;
-  background-color: #3e2c5a;
-  border-color: #382851;
+  background-color: rgb(62.2918918919, 44.1837837838, 89.8162162162);
+  border-color: rgb(56.3648648649, 39.9797297297, 81.2702702703);
 }
 .btn-bootstrap:not(:disabled):not(.disabled):active:focus, .btn-bootstrap:not(:disabled):not(.disabled).active:focus, .show > .btn-bootstrap.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(111, 90, 144, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(111.35, 90.1, 143.65, 0.5);
 }
 
 .btn-outline-primary {
@@ -4436,7 +4436,7 @@ fieldset:disabled a.btn {
   text-decoration: none;
 }
 .btn-link:hover {
-  color: #027ce1;
+  color: rgb(2.2087378641, 123.6893203883, 225.2912621359);
   text-decoration: none;
 }
 .btn-link:focus, .btn-link.focus {
@@ -4708,7 +4708,7 @@ input[type=button].btn-block {
   border: 0;
 }
 .dropdown-item:hover, .dropdown-item:focus {
-  color: #16181b;
+  color: rgb(21.6283783784, 24.25, 26.8716216216);
   text-decoration: none;
   background-color: #f8f9fa;
 }
@@ -5051,12 +5051,12 @@ input[type=button].btn-block {
   box-shadow: 0 0 0 0.2rem rgba(51, 161, 253, 0.25);
 }
 .custom-control-input:focus:not(:checked) ~ .custom-control-label::before {
-  border-color: #b1dbfe;
+  border-color: rgb(177.2621359223, 219.1796116505, 254.2378640777);
 }
 .custom-control-input:not(:disabled):active ~ .custom-control-label::before {
   color: #fff;
-  background-color: #e4f2ff;
-  border-color: #e4f2ff;
+  background-color: rgb(227.7669902913, 242.4514563107, 254.7330097087);
+  border-color: rgb(227.7669902913, 242.4514563107, 254.7330097087);
 }
 .custom-control-input[disabled] ~ .custom-control-label, .custom-control-input:disabled ~ .custom-control-label {
   color: #6c757d;
@@ -5172,7 +5172,7 @@ input[type=button].btn-block {
           appearance: none;
 }
 .custom-select:focus {
-  border-color: #b1dbfe;
+  border-color: rgb(177.2621359223, 219.1796116505, 254.2378640777);
   outline: 0;
   box-shadow: 0 0 0 0.2rem rgba(51, 161, 253, 0.25);
 }
@@ -5230,7 +5230,7 @@ input[type=button].btn-block {
   opacity: 0;
 }
 .custom-file-input:focus ~ .custom-file-label {
-  border-color: #b1dbfe;
+  border-color: rgb(177.2621359223, 219.1796116505, 254.2378640777);
   box-shadow: 0 0 0 0.2rem rgba(51, 161, 253, 0.25);
 }
 .custom-file-input[disabled] ~ .custom-file-label, .custom-file-input:disabled ~ .custom-file-label {
@@ -5318,7 +5318,7 @@ input[type=button].btn-block {
   }
 }
 .custom-range::-webkit-slider-thumb:active {
-  background-color: #e4f2ff;
+  background-color: rgb(227.7669902913, 242.4514563107, 254.7330097087);
 }
 .custom-range::-webkit-slider-runnable-track {
   width: 100%;
@@ -5347,7 +5347,7 @@ input[type=button].btn-block {
   }
 }
 .custom-range::-moz-range-thumb:active {
-  background-color: #e4f2ff;
+  background-color: rgb(227.7669902913, 242.4514563107, 254.7330097087);
 }
 .custom-range::-moz-range-track {
   width: 100%;
@@ -5378,7 +5378,7 @@ input[type=button].btn-block {
   }
 }
 .custom-range::-ms-thumb:active {
-  background-color: #e4f2ff;
+  background-color: rgb(227.7669902913, 242.4514563107, 254.7330097087);
 }
 .custom-range::-ms-track {
   width: 100%;
@@ -6197,7 +6197,7 @@ input[type=button].btn-block {
 }
 .page-link:hover {
   z-index: 2;
-  color: #027ce1;
+  color: rgb(2.2087378641, 123.6893203883, 225.2912621359);
   text-decoration: none;
   background-color: #e9ecef;
   border-color: #dee2e6;
@@ -6301,7 +6301,7 @@ a.badge:hover, a.badge:focus {
 }
 a.badge-primary:hover, a.badge-primary:focus {
   color: #fff;
-  background-color: #028afb;
+  background-color: rgb(2.4563106796, 137.5533980583, 250.5436893204);
 }
 a.badge-primary:focus, a.badge-primary.focus {
   outline: 0;
@@ -6314,7 +6314,7 @@ a.badge-primary:focus, a.badge-primary.focus {
 }
 a.badge-secondary:hover, a.badge-secondary:focus {
   color: #fff;
-  background-color: #222733;
+  background-color: rgb(34.375, 39.375, 50.625);
 }
 a.badge-secondary:focus, a.badge-secondary.focus {
   outline: 0;
@@ -6327,7 +6327,7 @@ a.badge-secondary:focus, a.badge-secondary.focus {
 }
 a.badge-success:hover, a.badge-success:focus {
   color: #fff;
-  background-color: #1e7e34;
+  background-color: rgb(30.1449275362, 125.8550724638, 52);
 }
 a.badge-success:focus, a.badge-success.focus {
   outline: 0;
@@ -6340,7 +6340,7 @@ a.badge-success:focus, a.badge-success.focus {
 }
 a.badge-info:hover, a.badge-info:focus {
   color: #fff;
-  background-color: #117a8b;
+  background-color: rgb(17.3333333333, 122.0869565217, 138.6666666667);
 }
 a.badge-info:focus, a.badge-info.focus {
   outline: 0;
@@ -6353,7 +6353,7 @@ a.badge-info:focus, a.badge-info.focus {
 }
 a.badge-warning:hover, a.badge-warning:focus {
   color: #212529;
-  background-color: #d39e00;
+  background-color: rgb(211, 158.25, 0);
 }
 a.badge-warning:focus, a.badge-warning.focus {
   outline: 0;
@@ -6366,7 +6366,7 @@ a.badge-warning:focus, a.badge-warning.focus {
 }
 a.badge-danger:hover, a.badge-danger:focus {
   color: #fff;
-  background-color: #bd2130;
+  background-color: rgb(189.2151898734, 32.7848101266, 47.7721518987);
 }
 a.badge-danger:focus, a.badge-danger.focus {
   outline: 0;
@@ -6379,7 +6379,7 @@ a.badge-danger:focus, a.badge-danger.focus {
 }
 a.badge-light:hover, a.badge-light:focus {
   color: #212529;
-  background-color: #dae0e5;
+  background-color: rgb(218.25, 223.5, 228.75);
 }
 a.badge-light:focus, a.badge-light.focus {
   outline: 0;
@@ -6392,7 +6392,7 @@ a.badge-light:focus, a.badge-light.focus {
 }
 a.badge-dark:hover, a.badge-dark:focus {
   color: #fff;
-  background-color: #1d2124;
+  background-color: rgb(29.1379310345, 32.5, 35.8620689655);
 }
 a.badge-dark:focus, a.badge-dark.focus {
   outline: 0;
@@ -6418,7 +6418,7 @@ a.badge-black:focus, a.badge-black.focus {
 }
 a.badge-instagram:hover, a.badge-instagram:focus {
   color: #fff;
-  background-color: #d31e40;
+  background-color: rgb(211.1513761468, 29.8486238532, 64.119266055);
 }
 a.badge-instagram:focus, a.badge-instagram.focus {
   outline: 0;
@@ -6431,7 +6431,7 @@ a.badge-instagram:focus, a.badge-instagram.focus {
 }
 a.badge-facebook:hover, a.badge-facebook:focus {
   color: #fff;
-  background-color: #2d4474;
+  background-color: rgb(44.8066037736, 67.5896226415, 116.1933962264);
 }
 a.badge-facebook:focus, a.badge-facebook.focus {
   outline: 0;
@@ -6444,7 +6444,7 @@ a.badge-facebook:focus, a.badge-facebook.focus {
 }
 a.badge-messenger:hover, a.badge-messenger:focus {
   color: #fff;
-  background-color: #006acc;
+  background-color: rgb(0, 105.6, 204);
 }
 a.badge-messenger:focus, a.badge-messenger.focus {
   outline: 0;
@@ -6457,7 +6457,7 @@ a.badge-messenger:focus, a.badge-messenger.focus {
 }
 a.badge-youtube:hover, a.badge-youtube:focus {
   color: #fff;
-  background-color: #a11918;
+  background-color: rgb(160.6991525424, 25.0847457627, 24.3008474576);
 }
 a.badge-youtube:focus, a.badge-youtube.focus {
   outline: 0;
@@ -6470,7 +6470,7 @@ a.badge-youtube:focus, a.badge-youtube.focus {
 }
 a.badge-twitter:hover, a.badge-twitter:focus {
   color: #212529;
-  background-color: #2795e9;
+  background-color: rgb(38.6363636364, 149.3636363636, 233.3636363636);
 }
 a.badge-twitter:focus, a.badge-twitter.focus {
   outline: 0;
@@ -6483,7 +6483,7 @@ a.badge-twitter:focus, a.badge-twitter.focus {
 }
 a.badge-linkedin:hover, a.badge-linkedin:focus {
   color: #fff;
-  background-color: #005582;
+  background-color: rgb(0, 85.4696132597, 130);
 }
 a.badge-linkedin:focus, a.badge-linkedin.focus {
   outline: 0;
@@ -6496,7 +6496,7 @@ a.badge-linkedin:focus, a.badge-linkedin.focus {
 }
 a.badge-snapchat:hover, a.badge-snapchat:focus {
   color: #212529;
-  background-color: #ccca00;
+  background-color: rgb(204, 201.6, 0);
 }
 a.badge-snapchat:focus, a.badge-snapchat.focus {
   outline: 0;
@@ -6509,7 +6509,7 @@ a.badge-snapchat:focus, a.badge-snapchat.focus {
 }
 a.badge-whatsapp:hover, a.badge-whatsapp:focus {
   color: #fff;
-  background-color: #1da851;
+  background-color: rgb(29.3911290323, 167.6088709677, 81.0241935484);
 }
 a.badge-whatsapp:focus, a.badge-whatsapp.focus {
   outline: 0;
@@ -6522,7 +6522,7 @@ a.badge-whatsapp:focus, a.badge-whatsapp.focus {
 }
 a.badge-skype:hover, a.badge-skype:focus {
   color: #fff;
-  background-color: #008abd;
+  background-color: rgb(0, 137.8125, 189);
 }
 a.badge-skype:focus, a.badge-skype.focus {
   outline: 0;
@@ -6535,7 +6535,7 @@ a.badge-skype:focus, a.badge-skype.focus {
 }
 a.badge-gray-100:hover, a.badge-gray-100:focus {
   color: #212529;
-  background-color: #dae0e5;
+  background-color: rgb(218.25, 223.5, 228.75);
 }
 a.badge-gray-100:focus, a.badge-gray-100.focus {
   outline: 0;
@@ -6548,7 +6548,7 @@ a.badge-gray-100:focus, a.badge-gray-100.focus {
 }
 a.badge-gray-200:hover, a.badge-gray-200:focus {
   color: #212529;
-  background-color: #cbd3da;
+  background-color: rgb(203.4736842105, 210.5, 217.5263157895);
 }
 a.badge-gray-200:focus, a.badge-gray-200.focus {
   outline: 0;
@@ -6561,7 +6561,7 @@ a.badge-gray-200:focus, a.badge-gray-200.focus {
 }
 a.badge-gray-300:hover, a.badge-gray-300:focus {
   color: #212529;
-  background-color: #c1c9d0;
+  background-color: rgb(192.9827586207, 200.5, 208.0172413793);
 }
 a.badge-gray-300:focus, a.badge-gray-300.focus {
   outline: 0;
@@ -6574,7 +6574,7 @@ a.badge-gray-300:focus, a.badge-gray-300.focus {
 }
 a.badge-gray-400:hover, a.badge-gray-400:focus {
   color: #212529;
-  background-color: #b1bbc4;
+  background-color: rgb(176.9418604651, 186.5, 196.0581395349);
 }
 a.badge-gray-400:focus, a.badge-gray-400.focus {
   outline: 0;
@@ -6587,7 +6587,7 @@ a.badge-gray-400:focus, a.badge-gray-400.focus {
 }
 a.badge-gray-500:hover, a.badge-gray-500:focus {
   color: #212529;
-  background-color: #919ca6;
+  background-color: rgb(144.7432432432, 155.5, 166.2567567568);
 }
 a.badge-gray-500:focus, a.badge-gray-500.focus {
   outline: 0;
@@ -6600,7 +6600,7 @@ a.badge-gray-500:focus, a.badge-gray-500.focus {
 }
 a.badge-gray-600:hover, a.badge-gray-600:focus {
   color: #fff;
-  background-color: #545b62;
+  background-color: rgb(84.3605150215, 91.3905579399, 97.6394849785);
 }
 a.badge-gray-600:focus, a.badge-gray-600.focus {
   outline: 0;
@@ -6613,7 +6613,7 @@ a.badge-gray-600:focus, a.badge-gray-600.focus {
 }
 a.badge-gray-700:hover, a.badge-gray-700:focus {
   color: #fff;
-  background-color: #32373b;
+  background-color: rgb(49.73125, 54.5, 59.26875);
 }
 a.badge-gray-700:focus, a.badge-gray-700.focus {
   outline: 0;
@@ -6626,7 +6626,7 @@ a.badge-gray-700:focus, a.badge-gray-700.focus {
 }
 a.badge-gray-800:hover, a.badge-gray-800:focus {
   color: #fff;
-  background-color: #1d2124;
+  background-color: rgb(29.1379310345, 32.5, 35.8620689655);
 }
 a.badge-gray-800:focus, a.badge-gray-800.focus {
   outline: 0;
@@ -6639,7 +6639,7 @@ a.badge-gray-800:focus, a.badge-gray-800.focus {
 }
 a.badge-gray-900:hover, a.badge-gray-900:focus {
   color: #fff;
-  background-color: #0a0c0d;
+  background-color: rgb(10.2567567568, 11.5, 12.7432432432);
 }
 a.badge-gray-900:focus, a.badge-gray-900.focus {
   outline: 0;
@@ -6652,7 +6652,7 @@ a.badge-gray-900:focus, a.badge-gray-900.focus {
 }
 a.badge-bootstrap:hover, a.badge-bootstrap:focus {
   color: #fff;
-  background-color: #3e2c5a;
+  background-color: rgb(62.2918918919, 44.1837837838, 89.8162162162);
 }
 a.badge-bootstrap:focus, a.badge-bootstrap.focus {
   outline: 0;
@@ -6706,339 +6706,339 @@ a.badge-bootstrap:focus, a.badge-bootstrap.focus {
 }
 
 .alert-primary {
-  color: #1b5484;
-  background-color: #d6ecff;
-  border-color: #c6e5fe;
+  color: rgb(26.52, 83.72, 131.56);
+  background-color: rgb(214.2, 236.2, 254.6);
+  border-color: rgb(197.88, 228.68, 254.44);
 }
 .alert-primary hr {
-  border-top-color: #addafe;
+  border-top-color: rgb(172.6275728155, 217.0440776699, 254.1924271845);
 }
 .alert-primary .alert-link {
-  color: #12395a;
+  color: rgb(17.9640789474, 56.7101315789, 89.1159210526);
 }
 
 .alert-secondary {
-  color: #1d212a;
-  background-color: #d7d9dc;
-  border-color: #c7c9ce;
+  color: rgb(28.6, 32.76, 42.12);
+  background-color: rgb(215, 216.6, 220.2);
+  border-color: rgb(199, 201.24, 206.28);
 }
 .alert-secondary hr {
-  border-top-color: #b9bcc2;
+  border-top-color: rgb(185.3636363636, 188.1490909091, 194.4163636364);
 }
 .alert-secondary .alert-link {
-  color: #08090c;
+  color: rgb(7.975, 9.135, 11.745);
 }
 
 .alert-success {
-  color: #155724;
-  background-color: #d4edda;
-  border-color: #c3e6cb;
+  color: rgb(20.8, 86.84, 35.88);
+  background-color: rgb(212, 237.4, 217.8);
+  border-color: rgb(194.8, 230.36, 202.92);
 }
 .alert-success hr {
-  border-top-color: #b1dfbb;
+  border-top-color: rgb(176.7059405941, 222.9540594059, 187.2665346535);
 }
 .alert-success .alert-link {
-  color: #0b2e13;
+  color: rgb(10.9449275362, 45.6950724638, 18.88);
 }
 
 .alert-info {
-  color: #0c5460;
-  background-color: #d1ecf1;
-  border-color: #bee5eb;
+  color: rgb(11.96, 84.24, 95.68);
+  background-color: rgb(208.6, 236.4, 240.8);
+  border-color: rgb(190.04, 228.96, 235.12);
 }
 .alert-info hr {
-  border-top-color: #abdde5;
+  border-top-color: rgb(170.5152475248, 221.1332673267, 229.1447524752);
 }
 .alert-info .alert-link {
-  color: #062c33;
+  color: rgb(6.2933333333, 44.3269565217, 50.3466666667);
 }
 
 .alert-warning {
-  color: #856404;
-  background-color: #fff3cd;
-  border-color: #ffeeba;
+  color: rgb(132.6, 100.36, 3.64);
+  background-color: rgb(255, 242.6, 205.4);
+  border-color: rgb(255, 237.64, 185.56);
 }
 .alert-warning hr {
-  border-top-color: #ffe8a1;
+  border-top-color: rgb(255, 231.265, 160.06);
 }
 .alert-warning .alert-link {
-  color: #533f03;
+  color: rgb(82.9625954198, 62.7912977099, 2.2774045802);
 }
 
 .alert-danger {
-  color: #721c24;
-  background-color: #f8d7da;
-  border-color: #f5c6cb;
+  color: rgb(114.4, 27.56, 35.88);
+  background-color: rgb(248, 214.6, 217.8);
+  border-color: rgb(245.2, 198.44, 202.92);
 }
 .alert-danger hr {
-  border-top-color: #f1b0b7;
+  border-top-color: rgb(241.4341772152, 176.7058227848, 182.9073417722);
 }
 .alert-danger .alert-link {
-  color: #491217;
+  color: rgb(73.3010989011, 17.6589010989, 22.9898901099);
 }
 
 .alert-light {
-  color: #818182;
-  background-color: #fefefe;
-  border-color: #fdfdfe;
+  color: rgb(128.96, 129.48, 130);
+  background-color: rgb(253.6, 253.8, 254);
+  border-color: rgb(253.04, 253.32, 253.6);
 }
 .alert-light hr {
-  border-top-color: #ececf6;
+  border-top-color: rgb(238.165, 240.57, 242.975);
 }
 .alert-light .alert-link {
-  color: #686868;
+  color: rgb(103.5492351816, 103.98, 104.4107648184);
 }
 
 .alert-dark {
-  color: #1b1e21;
-  background-color: #d6d8d9;
-  border-color: #c6c8ca;
+  color: rgb(27.04, 30.16, 33.28);
+  background-color: rgb(214.4, 215.6, 216.8);
+  border-color: rgb(198.16, 199.84, 201.52);
 }
 .alert-dark hr {
-  border-top-color: #b9bbbe;
+  border-top-color: rgb(185.0216751269, 187.09, 189.1583248731);
 }
 .alert-dark .alert-link {
-  color: #040505;
+  color: rgb(4.1779310345, 4.66, 5.1420689655);
 }
 
 .alert-black {
   color: black;
   background-color: #cccccc;
-  border-color: #b8b8b8;
+  border-color: rgb(183.6, 183.6, 183.6);
 }
 .alert-black hr {
-  border-top-color: #ababab;
+  border-top-color: rgb(170.85, 170.85, 170.85);
 }
 .alert-black .alert-link {
   color: black;
 }
 
 .alert-instagram {
-  color: #772131;
-  background-color: #fad9df;
-  border-color: #f7cad2;
+  color: rgb(118.56, 33.28, 49.4);
+  background-color: rgb(249.6, 216.8, 223);
+  border-color: rgb(247.44, 201.52, 210.2);
 }
 .alert-instagram hr {
-  border-top-color: #f4b4bf;
+  border-top-color: rgb(244.2817431193, 179.1782568807, 191.4844036697);
 }
 .alert-instagram .alert-link {
-  color: #4f1621;
+  color: rgb(78.7380821918, 22.1019178082, 32.8075342466);
 }
 
 .alert-facebook {
-  color: #1f2e50;
-  background-color: #d8deeb;
-  border-color: #c8d1e2;
+  color: rgb(30.68, 46.28, 79.56);
+  background-color: rgb(215.8, 221.8, 234.6);
+  border-color: rgb(200.12, 208.52, 226.44);
 }
 .alert-facebook hr {
-  border-top-color: #b7c3d9;
+  border-top-color: rgb(183.3481879195, 194.3153020134, 217.7118120805);
 }
 .alert-facebook .alert-link {
-  color: #11192b;
+  color: rgb(16.4866037736, 24.8696226415, 42.7533962264);
 }
 
 .alert-messenger {
-  color: #004585;
-  background-color: #cce6ff;
-  border-color: #b8ddff;
+  color: rgb(0, 68.64, 132.6);
+  background-color: rgb(204, 230.4, 255);
+  border-color: rgb(183.6, 220.56, 255);
 }
 .alert-messenger hr {
-  border-top-color: #9fd1ff;
+  border-top-color: rgb(158.1, 208.26, 255);
 }
 .alert-messenger .alert-link {
-  color: #002b52;
+  color: rgb(0, 42.24, 81.6);
 }
 
 .alert-youtube {
-  color: #6b1110;
-  background-color: #f5d2d2;
-  border-color: #f1c1c0;
+  color: rgb(106.6, 16.64, 16.12);
+  background-color: rgb(245, 210.4, 210.2);
+  border-color: rgb(241, 192.56, 192.28);
 }
 .alert-youtube hr {
-  border-top-color: #ecacab;
+  border-top-color: rgb(236.3467153285, 171.806350365, 171.4332846715);
 }
 .alert-youtube .alert-link {
-  color: #3f0a09;
+  color: rgb(62.2991525424, 9.7247457627, 9.4208474576);
 }
 
 .alert-twitter {
-  color: #2c597c;
-  background-color: #ddeefc;
-  border-color: #cfe8fa;
+  color: rgb(44.2, 89.44, 123.76);
+  background-color: rgb(221, 238.4, 251.6);
+  border-color: rgb(207.4, 231.76, 250.24);
 }
 .alert-twitter hr {
-  border-top-color: #b8ddf8;
+  border-top-color: rgb(184.2181818182, 220.4418181818, 247.9218181818);
 }
 .alert-twitter .alert-link {
-  color: #1f3e56;
+  color: rgb(30.7789473684, 62.2821052632, 86.1810526316);
 }
 
 .alert-linkedin {
-  color: #003e5e;
-  background-color: #cce4f0;
-  border-color: #b8d9ea;
+  color: rgb(0, 61.88, 94.12);
+  background-color: rgb(204, 227.8, 240.2);
+  border-color: rgb(183.6, 216.92, 234.28);
 }
 .alert-linkedin hr {
-  border-top-color: #a4cee4;
+  border-top-color: rgb(163.83556231, 206.3789665653, 228.54443769);
 }
 .alert-linkedin .alert-link {
-  color: #001c2b;
+  color: rgb(0, 28.3496132597, 43.12);
 }
 
 .alert-snapchat {
-  color: #858300;
-  background-color: #fffecc;
-  border-color: #fffeb8;
+  color: rgb(132.6, 131.04, 0);
+  background-color: rgb(255, 254.4, 204);
+  border-color: rgb(255, 254.16, 183.6);
 }
 .alert-snapchat hr {
-  border-top-color: #fffe9f;
+  border-top-color: rgb(255, 253.86, 158.1);
 }
 .alert-snapchat .alert-link {
-  color: #525100;
+  color: rgb(81.6, 80.64, 0);
 }
 
 .alert-whatsapp {
-  color: #136e35;
-  background-color: #d3f6e0;
-  border-color: #c2f3d4;
+  color: rgb(19.24, 109.72, 53.04);
+  background-color: rgb(211.4, 246.2, 224.4);
+  border-color: rgb(193.96, 242.68, 212.16);
 }
 .alert-whatsapp hr {
-  border-top-color: #adefc5;
+  border-top-color: rgb(172.7424427481, 238.3975572519, 197.268778626);
 }
 .alert-whatsapp .alert-link {
-  color: #0b4320;
+  color: rgb(11.6311290323, 66.3288709677, 32.0641935484);
 }
 
 .alert-skype {
-  color: #005b7d;
+  color: rgb(0, 91, 124.8);
   background-color: #cceffc;
-  border-color: #b8e9fb;
+  border-color: rgb(183.6, 232.6, 250.8);
 }
 .alert-skype hr {
-  border-top-color: #a0e2fa;
+  border-top-color: rgb(159.5166666667, 225.0444444444, 249.3833333333);
 }
 .alert-skype .alert-link {
-  color: #00364a;
+  color: rgb(0, 53.8125, 73.8);
 }
 
 .alert-gray-100 {
-  color: #818182;
-  background-color: #fefefe;
-  border-color: #fdfdfe;
+  color: rgb(128.96, 129.48, 130);
+  background-color: rgb(253.6, 253.8, 254);
+  border-color: rgb(253.04, 253.32, 253.6);
 }
 .alert-gray-100 hr {
-  border-top-color: #ececf6;
+  border-top-color: rgb(238.165, 240.57, 242.975);
 }
 .alert-gray-100 .alert-link {
-  color: #686868;
+  color: rgb(103.5492351816, 103.98, 104.4107648184);
 }
 
 .alert-gray-200 {
-  color: #797b7c;
-  background-color: #fbfbfc;
-  border-color: #f9fafb;
+  color: rgb(121.16, 122.72, 124.28);
+  background-color: rgb(250.6, 251.2, 251.8);
+  border-color: rgb(248.84, 249.68, 250.52);
 }
 .alert-gray-200 hr {
-  border-top-color: #eaedf1;
+  border-top-color: rgb(234.0768421053, 236.93, 239.7831578947);
 }
 .alert-gray-200 .alert-link {
-  color: #606162;
+  color: rgb(95.9841525424, 97.22, 98.4558474576);
 }
 
 .alert-gray-300 {
-  color: #737678;
-  background-color: #f8f9fa;
-  border-color: #f6f7f8;
+  color: rgb(115.44, 117.52, 119.6);
+  background-color: rgb(248.4, 249.2, 250);
+  border-color: rgb(245.76, 246.88, 248);
 }
 .alert-gray-300 hr {
-  border-top-color: #e8eaed;
+  border-top-color: rgb(231.2513793103, 234.13, 237.0086206897);
 }
 .alert-gray-300 .alert-link {
-  color: #5a5c5e;
+  color: rgb(90.3913274336, 92.02, 93.6486725664);
 }
 
 .alert-gray-400 {
-  color: #6b6e71;
-  background-color: #f5f6f8;
-  border-color: #f1f3f5;
+  color: rgb(107.12, 110.24, 113.36);
+  background-color: rgb(245.2, 246.4, 247.6);
+  border-color: rgb(241.28, 242.96, 244.64);
 }
 .alert-gray-400 hr {
-  border-top-color: #e2e6ea;
+  border-top-color: rgb(226.7509302326, 230.21, 233.6690697674);
 }
 .alert-gray-400 .alert-link {
-  color: #525557;
+  color: rgb(82.3416981132, 84.74, 87.1383018868);
 }
 
 .alert-gray-500 {
-  color: #5a5e62;
-  background-color: #eff0f2;
-  border-color: #e8eaed;
+  color: rgb(89.96, 94.12, 98.28);
+  background-color: rgb(238.6, 240.2, 241.8);
+  border-color: rgb(232.04, 234.28, 236.52);
 }
 .alert-gray-500 hr {
-  border-top-color: #dadde2;
+  border-top-color: rgb(217.9116216216, 221.53, 225.1483783784);
 }
 .alert-gray-500 .alert-link {
-  color: #424547;
+  color: rgb(65.5870718232, 68.62, 71.6529281768);
 }
 
 .alert-gray-600 {
-  color: #383d41;
-  background-color: #e2e3e5;
-  border-color: #d6d8db;
+  color: rgb(56.16, 60.84, 65);
+  background-color: rgb(225.6, 227.4, 229);
+  border-color: rgb(213.84, 216.36, 218.6);
 }
 .alert-gray-600 hr {
-  border-top-color: #c8cbcf;
+  border-top-color: rgb(200.3075090253, 203.6560288809, 206.6324909747);
 }
 .alert-gray-600 .alert-link {
-  color: #202326;
+  color: rgb(32.5205150215, 35.2305579399, 37.6394849785);
 }
 
 .alert-gray-700 {
-  color: #262a2d;
-  background-color: #dbdcdd;
-  border-color: #ccced0;
+  color: rgb(37.96, 41.6, 45.24);
+  background-color: rgb(218.6, 220, 221.4);
+  border-color: rgb(204.04, 206, 207.96);
 }
 .alert-gray-700 hr {
-  border-top-color: #bfc1c4;
+  border-top-color: rgb(190.78, 193.25, 195.72);
 }
 .alert-gray-700 .alert-link {
-  color: #0f1011;
+  color: rgb(14.69125, 16.1, 17.50875);
 }
 
 .alert-gray-800 {
-  color: #1b1e21;
-  background-color: #d6d8d9;
-  border-color: #c6c8ca;
+  color: rgb(27.04, 30.16, 33.28);
+  background-color: rgb(214.4, 215.6, 216.8);
+  border-color: rgb(198.16, 199.84, 201.52);
 }
 .alert-gray-800 hr {
-  border-top-color: #b9bbbe;
+  border-top-color: rgb(185.0216751269, 187.09, 189.1583248731);
 }
 .alert-gray-800 .alert-link {
-  color: #040505;
+  color: rgb(4.1779310345, 4.66, 5.1420689655);
 }
 
 .alert-gray-900 {
-  color: #111315;
-  background-color: #d3d3d4;
-  border-color: #c1c2c3;
+  color: rgb(17.16, 19.24, 21.32);
+  background-color: rgb(210.6, 211.4, 212.2);
+  border-color: rgb(192.84, 193.96, 195.08);
 }
 .alert-gray-900 hr {
-  border-top-color: #b4b5b6;
+  border-top-color: rgb(179.8560550459, 181.21, 182.5639449541);
 }
 .alert-gray-900 .alert-link {
   color: black;
 }
 
 .alert-bootstrap {
-  color: #2d2040;
-  background-color: #ddd8e5;
-  border-color: #d0c9da;
+  color: rgb(44.72, 31.72, 64.48);
+  background-color: rgb(221.2, 216.2, 228.8);
+  border-color: rgb(207.68, 200.68, 218.32);
 }
 .alert-bootstrap hr {
-  border-top-color: #c3bad0;
+  border-top-color: rgb(194.42, 185.4584615385, 208.0415384615);
 }
 .alert-bootstrap .alert-link {
-  color: #150f1e;
+  color: rgb(21.0118918919, 14.9037837838, 30.2962162162);
 }
 
 @keyframes progress-bar-stripes {
@@ -7311,124 +7311,124 @@ a.badge-bootstrap:focus, a.badge-bootstrap.focus {
 }
 
 .list-group-item-primary {
-  color: #1b5484;
-  background-color: #c6e5fe;
+  color: rgb(26.52, 83.72, 131.56);
+  background-color: rgb(197.88, 228.68, 254.44);
 }
 .list-group-item-primary.list-group-item-action:hover, .list-group-item-primary.list-group-item-action:focus {
-  color: #1b5484;
-  background-color: #addafe;
+  color: rgb(26.52, 83.72, 131.56);
+  background-color: rgb(172.6275728155, 217.0440776699, 254.1924271845);
 }
 .list-group-item-primary.list-group-item-action.active {
   color: #fff;
-  background-color: #1b5484;
-  border-color: #1b5484;
+  background-color: rgb(26.52, 83.72, 131.56);
+  border-color: rgb(26.52, 83.72, 131.56);
 }
 
 .list-group-item-secondary {
-  color: #1d212a;
-  background-color: #c7c9ce;
+  color: rgb(28.6, 32.76, 42.12);
+  background-color: rgb(199, 201.24, 206.28);
 }
 .list-group-item-secondary.list-group-item-action:hover, .list-group-item-secondary.list-group-item-action:focus {
-  color: #1d212a;
-  background-color: #b9bcc2;
+  color: rgb(28.6, 32.76, 42.12);
+  background-color: rgb(185.3636363636, 188.1490909091, 194.4163636364);
 }
 .list-group-item-secondary.list-group-item-action.active {
   color: #fff;
-  background-color: #1d212a;
-  border-color: #1d212a;
+  background-color: rgb(28.6, 32.76, 42.12);
+  border-color: rgb(28.6, 32.76, 42.12);
 }
 
 .list-group-item-success {
-  color: #155724;
-  background-color: #c3e6cb;
+  color: rgb(20.8, 86.84, 35.88);
+  background-color: rgb(194.8, 230.36, 202.92);
 }
 .list-group-item-success.list-group-item-action:hover, .list-group-item-success.list-group-item-action:focus {
-  color: #155724;
-  background-color: #b1dfbb;
+  color: rgb(20.8, 86.84, 35.88);
+  background-color: rgb(176.7059405941, 222.9540594059, 187.2665346535);
 }
 .list-group-item-success.list-group-item-action.active {
   color: #fff;
-  background-color: #155724;
-  border-color: #155724;
+  background-color: rgb(20.8, 86.84, 35.88);
+  border-color: rgb(20.8, 86.84, 35.88);
 }
 
 .list-group-item-info {
-  color: #0c5460;
-  background-color: #bee5eb;
+  color: rgb(11.96, 84.24, 95.68);
+  background-color: rgb(190.04, 228.96, 235.12);
 }
 .list-group-item-info.list-group-item-action:hover, .list-group-item-info.list-group-item-action:focus {
-  color: #0c5460;
-  background-color: #abdde5;
+  color: rgb(11.96, 84.24, 95.68);
+  background-color: rgb(170.5152475248, 221.1332673267, 229.1447524752);
 }
 .list-group-item-info.list-group-item-action.active {
   color: #fff;
-  background-color: #0c5460;
-  border-color: #0c5460;
+  background-color: rgb(11.96, 84.24, 95.68);
+  border-color: rgb(11.96, 84.24, 95.68);
 }
 
 .list-group-item-warning {
-  color: #856404;
-  background-color: #ffeeba;
+  color: rgb(132.6, 100.36, 3.64);
+  background-color: rgb(255, 237.64, 185.56);
 }
 .list-group-item-warning.list-group-item-action:hover, .list-group-item-warning.list-group-item-action:focus {
-  color: #856404;
-  background-color: #ffe8a1;
+  color: rgb(132.6, 100.36, 3.64);
+  background-color: rgb(255, 231.265, 160.06);
 }
 .list-group-item-warning.list-group-item-action.active {
   color: #fff;
-  background-color: #856404;
-  border-color: #856404;
+  background-color: rgb(132.6, 100.36, 3.64);
+  border-color: rgb(132.6, 100.36, 3.64);
 }
 
 .list-group-item-danger {
-  color: #721c24;
-  background-color: #f5c6cb;
+  color: rgb(114.4, 27.56, 35.88);
+  background-color: rgb(245.2, 198.44, 202.92);
 }
 .list-group-item-danger.list-group-item-action:hover, .list-group-item-danger.list-group-item-action:focus {
-  color: #721c24;
-  background-color: #f1b0b7;
+  color: rgb(114.4, 27.56, 35.88);
+  background-color: rgb(241.4341772152, 176.7058227848, 182.9073417722);
 }
 .list-group-item-danger.list-group-item-action.active {
   color: #fff;
-  background-color: #721c24;
-  border-color: #721c24;
+  background-color: rgb(114.4, 27.56, 35.88);
+  border-color: rgb(114.4, 27.56, 35.88);
 }
 
 .list-group-item-light {
-  color: #818182;
-  background-color: #fdfdfe;
+  color: rgb(128.96, 129.48, 130);
+  background-color: rgb(253.04, 253.32, 253.6);
 }
 .list-group-item-light.list-group-item-action:hover, .list-group-item-light.list-group-item-action:focus {
-  color: #818182;
-  background-color: #ececf6;
+  color: rgb(128.96, 129.48, 130);
+  background-color: rgb(238.165, 240.57, 242.975);
 }
 .list-group-item-light.list-group-item-action.active {
   color: #fff;
-  background-color: #818182;
-  border-color: #818182;
+  background-color: rgb(128.96, 129.48, 130);
+  border-color: rgb(128.96, 129.48, 130);
 }
 
 .list-group-item-dark {
-  color: #1b1e21;
-  background-color: #c6c8ca;
+  color: rgb(27.04, 30.16, 33.28);
+  background-color: rgb(198.16, 199.84, 201.52);
 }
 .list-group-item-dark.list-group-item-action:hover, .list-group-item-dark.list-group-item-action:focus {
-  color: #1b1e21;
-  background-color: #b9bbbe;
+  color: rgb(27.04, 30.16, 33.28);
+  background-color: rgb(185.0216751269, 187.09, 189.1583248731);
 }
 .list-group-item-dark.list-group-item-action.active {
   color: #fff;
-  background-color: #1b1e21;
-  border-color: #1b1e21;
+  background-color: rgb(27.04, 30.16, 33.28);
+  border-color: rgb(27.04, 30.16, 33.28);
 }
 
 .list-group-item-black {
   color: black;
-  background-color: #b8b8b8;
+  background-color: rgb(183.6, 183.6, 183.6);
 }
 .list-group-item-black.list-group-item-action:hover, .list-group-item-black.list-group-item-action:focus {
   color: black;
-  background-color: #ababab;
+  background-color: rgb(170.85, 170.85, 170.85);
 }
 .list-group-item-black.list-group-item-action.active {
   color: #fff;
@@ -7437,269 +7437,269 @@ a.badge-bootstrap:focus, a.badge-bootstrap.focus {
 }
 
 .list-group-item-instagram {
-  color: #772131;
-  background-color: #f7cad2;
+  color: rgb(118.56, 33.28, 49.4);
+  background-color: rgb(247.44, 201.52, 210.2);
 }
 .list-group-item-instagram.list-group-item-action:hover, .list-group-item-instagram.list-group-item-action:focus {
-  color: #772131;
-  background-color: #f4b4bf;
+  color: rgb(118.56, 33.28, 49.4);
+  background-color: rgb(244.2817431193, 179.1782568807, 191.4844036697);
 }
 .list-group-item-instagram.list-group-item-action.active {
   color: #fff;
-  background-color: #772131;
-  border-color: #772131;
+  background-color: rgb(118.56, 33.28, 49.4);
+  border-color: rgb(118.56, 33.28, 49.4);
 }
 
 .list-group-item-facebook {
-  color: #1f2e50;
-  background-color: #c8d1e2;
+  color: rgb(30.68, 46.28, 79.56);
+  background-color: rgb(200.12, 208.52, 226.44);
 }
 .list-group-item-facebook.list-group-item-action:hover, .list-group-item-facebook.list-group-item-action:focus {
-  color: #1f2e50;
-  background-color: #b7c3d9;
+  color: rgb(30.68, 46.28, 79.56);
+  background-color: rgb(183.3481879195, 194.3153020134, 217.7118120805);
 }
 .list-group-item-facebook.list-group-item-action.active {
   color: #fff;
-  background-color: #1f2e50;
-  border-color: #1f2e50;
+  background-color: rgb(30.68, 46.28, 79.56);
+  border-color: rgb(30.68, 46.28, 79.56);
 }
 
 .list-group-item-messenger {
-  color: #004585;
-  background-color: #b8ddff;
+  color: rgb(0, 68.64, 132.6);
+  background-color: rgb(183.6, 220.56, 255);
 }
 .list-group-item-messenger.list-group-item-action:hover, .list-group-item-messenger.list-group-item-action:focus {
-  color: #004585;
-  background-color: #9fd1ff;
+  color: rgb(0, 68.64, 132.6);
+  background-color: rgb(158.1, 208.26, 255);
 }
 .list-group-item-messenger.list-group-item-action.active {
   color: #fff;
-  background-color: #004585;
-  border-color: #004585;
+  background-color: rgb(0, 68.64, 132.6);
+  border-color: rgb(0, 68.64, 132.6);
 }
 
 .list-group-item-youtube {
-  color: #6b1110;
-  background-color: #f1c1c0;
+  color: rgb(106.6, 16.64, 16.12);
+  background-color: rgb(241, 192.56, 192.28);
 }
 .list-group-item-youtube.list-group-item-action:hover, .list-group-item-youtube.list-group-item-action:focus {
-  color: #6b1110;
-  background-color: #ecacab;
+  color: rgb(106.6, 16.64, 16.12);
+  background-color: rgb(236.3467153285, 171.806350365, 171.4332846715);
 }
 .list-group-item-youtube.list-group-item-action.active {
   color: #fff;
-  background-color: #6b1110;
-  border-color: #6b1110;
+  background-color: rgb(106.6, 16.64, 16.12);
+  border-color: rgb(106.6, 16.64, 16.12);
 }
 
 .list-group-item-twitter {
-  color: #2c597c;
-  background-color: #cfe8fa;
+  color: rgb(44.2, 89.44, 123.76);
+  background-color: rgb(207.4, 231.76, 250.24);
 }
 .list-group-item-twitter.list-group-item-action:hover, .list-group-item-twitter.list-group-item-action:focus {
-  color: #2c597c;
-  background-color: #b8ddf8;
+  color: rgb(44.2, 89.44, 123.76);
+  background-color: rgb(184.2181818182, 220.4418181818, 247.9218181818);
 }
 .list-group-item-twitter.list-group-item-action.active {
   color: #fff;
-  background-color: #2c597c;
-  border-color: #2c597c;
+  background-color: rgb(44.2, 89.44, 123.76);
+  border-color: rgb(44.2, 89.44, 123.76);
 }
 
 .list-group-item-linkedin {
-  color: #003e5e;
-  background-color: #b8d9ea;
+  color: rgb(0, 61.88, 94.12);
+  background-color: rgb(183.6, 216.92, 234.28);
 }
 .list-group-item-linkedin.list-group-item-action:hover, .list-group-item-linkedin.list-group-item-action:focus {
-  color: #003e5e;
-  background-color: #a4cee4;
+  color: rgb(0, 61.88, 94.12);
+  background-color: rgb(163.83556231, 206.3789665653, 228.54443769);
 }
 .list-group-item-linkedin.list-group-item-action.active {
   color: #fff;
-  background-color: #003e5e;
-  border-color: #003e5e;
+  background-color: rgb(0, 61.88, 94.12);
+  border-color: rgb(0, 61.88, 94.12);
 }
 
 .list-group-item-snapchat {
-  color: #858300;
-  background-color: #fffeb8;
+  color: rgb(132.6, 131.04, 0);
+  background-color: rgb(255, 254.16, 183.6);
 }
 .list-group-item-snapchat.list-group-item-action:hover, .list-group-item-snapchat.list-group-item-action:focus {
-  color: #858300;
-  background-color: #fffe9f;
+  color: rgb(132.6, 131.04, 0);
+  background-color: rgb(255, 253.86, 158.1);
 }
 .list-group-item-snapchat.list-group-item-action.active {
   color: #fff;
-  background-color: #858300;
-  border-color: #858300;
+  background-color: rgb(132.6, 131.04, 0);
+  border-color: rgb(132.6, 131.04, 0);
 }
 
 .list-group-item-whatsapp {
-  color: #136e35;
-  background-color: #c2f3d4;
+  color: rgb(19.24, 109.72, 53.04);
+  background-color: rgb(193.96, 242.68, 212.16);
 }
 .list-group-item-whatsapp.list-group-item-action:hover, .list-group-item-whatsapp.list-group-item-action:focus {
-  color: #136e35;
-  background-color: #adefc5;
+  color: rgb(19.24, 109.72, 53.04);
+  background-color: rgb(172.7424427481, 238.3975572519, 197.268778626);
 }
 .list-group-item-whatsapp.list-group-item-action.active {
   color: #fff;
-  background-color: #136e35;
-  border-color: #136e35;
+  background-color: rgb(19.24, 109.72, 53.04);
+  border-color: rgb(19.24, 109.72, 53.04);
 }
 
 .list-group-item-skype {
-  color: #005b7d;
-  background-color: #b8e9fb;
+  color: rgb(0, 91, 124.8);
+  background-color: rgb(183.6, 232.6, 250.8);
 }
 .list-group-item-skype.list-group-item-action:hover, .list-group-item-skype.list-group-item-action:focus {
-  color: #005b7d;
-  background-color: #a0e2fa;
+  color: rgb(0, 91, 124.8);
+  background-color: rgb(159.5166666667, 225.0444444444, 249.3833333333);
 }
 .list-group-item-skype.list-group-item-action.active {
   color: #fff;
-  background-color: #005b7d;
-  border-color: #005b7d;
+  background-color: rgb(0, 91, 124.8);
+  border-color: rgb(0, 91, 124.8);
 }
 
 .list-group-item-gray-100 {
-  color: #818182;
-  background-color: #fdfdfe;
+  color: rgb(128.96, 129.48, 130);
+  background-color: rgb(253.04, 253.32, 253.6);
 }
 .list-group-item-gray-100.list-group-item-action:hover, .list-group-item-gray-100.list-group-item-action:focus {
-  color: #818182;
-  background-color: #ececf6;
+  color: rgb(128.96, 129.48, 130);
+  background-color: rgb(238.165, 240.57, 242.975);
 }
 .list-group-item-gray-100.list-group-item-action.active {
   color: #fff;
-  background-color: #818182;
-  border-color: #818182;
+  background-color: rgb(128.96, 129.48, 130);
+  border-color: rgb(128.96, 129.48, 130);
 }
 
 .list-group-item-gray-200 {
-  color: #797b7c;
-  background-color: #f9fafb;
+  color: rgb(121.16, 122.72, 124.28);
+  background-color: rgb(248.84, 249.68, 250.52);
 }
 .list-group-item-gray-200.list-group-item-action:hover, .list-group-item-gray-200.list-group-item-action:focus {
-  color: #797b7c;
-  background-color: #eaedf1;
+  color: rgb(121.16, 122.72, 124.28);
+  background-color: rgb(234.0768421053, 236.93, 239.7831578947);
 }
 .list-group-item-gray-200.list-group-item-action.active {
   color: #fff;
-  background-color: #797b7c;
-  border-color: #797b7c;
+  background-color: rgb(121.16, 122.72, 124.28);
+  border-color: rgb(121.16, 122.72, 124.28);
 }
 
 .list-group-item-gray-300 {
-  color: #737678;
-  background-color: #f6f7f8;
+  color: rgb(115.44, 117.52, 119.6);
+  background-color: rgb(245.76, 246.88, 248);
 }
 .list-group-item-gray-300.list-group-item-action:hover, .list-group-item-gray-300.list-group-item-action:focus {
-  color: #737678;
-  background-color: #e8eaed;
+  color: rgb(115.44, 117.52, 119.6);
+  background-color: rgb(231.2513793103, 234.13, 237.0086206897);
 }
 .list-group-item-gray-300.list-group-item-action.active {
   color: #fff;
-  background-color: #737678;
-  border-color: #737678;
+  background-color: rgb(115.44, 117.52, 119.6);
+  border-color: rgb(115.44, 117.52, 119.6);
 }
 
 .list-group-item-gray-400 {
-  color: #6b6e71;
-  background-color: #f1f3f5;
+  color: rgb(107.12, 110.24, 113.36);
+  background-color: rgb(241.28, 242.96, 244.64);
 }
 .list-group-item-gray-400.list-group-item-action:hover, .list-group-item-gray-400.list-group-item-action:focus {
-  color: #6b6e71;
-  background-color: #e2e6ea;
+  color: rgb(107.12, 110.24, 113.36);
+  background-color: rgb(226.7509302326, 230.21, 233.6690697674);
 }
 .list-group-item-gray-400.list-group-item-action.active {
   color: #fff;
-  background-color: #6b6e71;
-  border-color: #6b6e71;
+  background-color: rgb(107.12, 110.24, 113.36);
+  border-color: rgb(107.12, 110.24, 113.36);
 }
 
 .list-group-item-gray-500 {
-  color: #5a5e62;
-  background-color: #e8eaed;
+  color: rgb(89.96, 94.12, 98.28);
+  background-color: rgb(232.04, 234.28, 236.52);
 }
 .list-group-item-gray-500.list-group-item-action:hover, .list-group-item-gray-500.list-group-item-action:focus {
-  color: #5a5e62;
-  background-color: #dadde2;
+  color: rgb(89.96, 94.12, 98.28);
+  background-color: rgb(217.9116216216, 221.53, 225.1483783784);
 }
 .list-group-item-gray-500.list-group-item-action.active {
   color: #fff;
-  background-color: #5a5e62;
-  border-color: #5a5e62;
+  background-color: rgb(89.96, 94.12, 98.28);
+  border-color: rgb(89.96, 94.12, 98.28);
 }
 
 .list-group-item-gray-600 {
-  color: #383d41;
-  background-color: #d6d8db;
+  color: rgb(56.16, 60.84, 65);
+  background-color: rgb(213.84, 216.36, 218.6);
 }
 .list-group-item-gray-600.list-group-item-action:hover, .list-group-item-gray-600.list-group-item-action:focus {
-  color: #383d41;
-  background-color: #c8cbcf;
+  color: rgb(56.16, 60.84, 65);
+  background-color: rgb(200.3075090253, 203.6560288809, 206.6324909747);
 }
 .list-group-item-gray-600.list-group-item-action.active {
   color: #fff;
-  background-color: #383d41;
-  border-color: #383d41;
+  background-color: rgb(56.16, 60.84, 65);
+  border-color: rgb(56.16, 60.84, 65);
 }
 
 .list-group-item-gray-700 {
-  color: #262a2d;
-  background-color: #ccced0;
+  color: rgb(37.96, 41.6, 45.24);
+  background-color: rgb(204.04, 206, 207.96);
 }
 .list-group-item-gray-700.list-group-item-action:hover, .list-group-item-gray-700.list-group-item-action:focus {
-  color: #262a2d;
-  background-color: #bfc1c4;
+  color: rgb(37.96, 41.6, 45.24);
+  background-color: rgb(190.78, 193.25, 195.72);
 }
 .list-group-item-gray-700.list-group-item-action.active {
   color: #fff;
-  background-color: #262a2d;
-  border-color: #262a2d;
+  background-color: rgb(37.96, 41.6, 45.24);
+  border-color: rgb(37.96, 41.6, 45.24);
 }
 
 .list-group-item-gray-800 {
-  color: #1b1e21;
-  background-color: #c6c8ca;
+  color: rgb(27.04, 30.16, 33.28);
+  background-color: rgb(198.16, 199.84, 201.52);
 }
 .list-group-item-gray-800.list-group-item-action:hover, .list-group-item-gray-800.list-group-item-action:focus {
-  color: #1b1e21;
-  background-color: #b9bbbe;
+  color: rgb(27.04, 30.16, 33.28);
+  background-color: rgb(185.0216751269, 187.09, 189.1583248731);
 }
 .list-group-item-gray-800.list-group-item-action.active {
   color: #fff;
-  background-color: #1b1e21;
-  border-color: #1b1e21;
+  background-color: rgb(27.04, 30.16, 33.28);
+  border-color: rgb(27.04, 30.16, 33.28);
 }
 
 .list-group-item-gray-900 {
-  color: #111315;
-  background-color: #c1c2c3;
+  color: rgb(17.16, 19.24, 21.32);
+  background-color: rgb(192.84, 193.96, 195.08);
 }
 .list-group-item-gray-900.list-group-item-action:hover, .list-group-item-gray-900.list-group-item-action:focus {
-  color: #111315;
-  background-color: #b4b5b6;
+  color: rgb(17.16, 19.24, 21.32);
+  background-color: rgb(179.8560550459, 181.21, 182.5639449541);
 }
 .list-group-item-gray-900.list-group-item-action.active {
   color: #fff;
-  background-color: #111315;
-  border-color: #111315;
+  background-color: rgb(17.16, 19.24, 21.32);
+  border-color: rgb(17.16, 19.24, 21.32);
 }
 
 .list-group-item-bootstrap {
-  color: #2d2040;
-  background-color: #d0c9da;
+  color: rgb(44.72, 31.72, 64.48);
+  background-color: rgb(207.68, 200.68, 218.32);
 }
 .list-group-item-bootstrap.list-group-item-action:hover, .list-group-item-bootstrap.list-group-item-action:focus {
-  color: #2d2040;
-  background-color: #c3bad0;
+  color: rgb(44.72, 31.72, 64.48);
+  background-color: rgb(194.42, 185.4584615385, 208.0415384615);
 }
 .list-group-item-bootstrap.list-group-item-action.active {
   color: #fff;
-  background-color: #2d2040;
-  border-color: #2d2040;
+  background-color: rgb(44.72, 31.72, 64.48);
+  border-color: rgb(44.72, 31.72, 64.48);
 }
 
 .close {
@@ -8171,7 +8171,7 @@ a.close.disabled {
   width: 1rem;
   margin-left: -0.5rem;
   content: "";
-  border-bottom: 1px solid #f7f7f7;
+  border-bottom: 1px solid rgb(247.35, 247.35, 247.35);
 }
 
 .bs-popover-left, .bs-popover-auto[x-placement^=left] {
@@ -8198,8 +8198,8 @@ a.close.disabled {
   padding: 0.5rem 0.75rem;
   margin-bottom: 0;
   font-size: 1rem;
-  background-color: #f7f7f7;
-  border-bottom: 1px solid #ebebeb;
+  background-color: rgb(247.35, 247.35, 247.35);
+  border-bottom: 1px solid rgb(234.6, 234.6, 234.6);
   border-top-left-radius: calc(0.3rem - 1px);
   border-top-right-radius: calc(0.3rem - 1px);
 }
@@ -8468,7 +8468,7 @@ a.close.disabled {
 a.bg-primary:hover, a.bg-primary:focus,
 button.bg-primary:hover,
 button.bg-primary:focus {
-  background-color: #028afb !important;
+  background-color: rgb(2.4563106796, 137.5533980583, 250.5436893204) !important;
 }
 
 .bg-secondary {
@@ -8478,7 +8478,7 @@ button.bg-primary:focus {
 a.bg-secondary:hover, a.bg-secondary:focus,
 button.bg-secondary:hover,
 button.bg-secondary:focus {
-  background-color: #222733 !important;
+  background-color: rgb(34.375, 39.375, 50.625) !important;
 }
 
 .bg-success {
@@ -8488,7 +8488,7 @@ button.bg-secondary:focus {
 a.bg-success:hover, a.bg-success:focus,
 button.bg-success:hover,
 button.bg-success:focus {
-  background-color: #1e7e34 !important;
+  background-color: rgb(30.1449275362, 125.8550724638, 52) !important;
 }
 
 .bg-info {
@@ -8498,7 +8498,7 @@ button.bg-success:focus {
 a.bg-info:hover, a.bg-info:focus,
 button.bg-info:hover,
 button.bg-info:focus {
-  background-color: #117a8b !important;
+  background-color: rgb(17.3333333333, 122.0869565217, 138.6666666667) !important;
 }
 
 .bg-warning {
@@ -8508,7 +8508,7 @@ button.bg-info:focus {
 a.bg-warning:hover, a.bg-warning:focus,
 button.bg-warning:hover,
 button.bg-warning:focus {
-  background-color: #d39e00 !important;
+  background-color: rgb(211, 158.25, 0) !important;
 }
 
 .bg-danger {
@@ -8518,7 +8518,7 @@ button.bg-warning:focus {
 a.bg-danger:hover, a.bg-danger:focus,
 button.bg-danger:hover,
 button.bg-danger:focus {
-  background-color: #bd2130 !important;
+  background-color: rgb(189.2151898734, 32.7848101266, 47.7721518987) !important;
 }
 
 .bg-light {
@@ -8528,7 +8528,7 @@ button.bg-danger:focus {
 a.bg-light:hover, a.bg-light:focus,
 button.bg-light:hover,
 button.bg-light:focus {
-  background-color: #dae0e5 !important;
+  background-color: rgb(218.25, 223.5, 228.75) !important;
 }
 
 .bg-dark {
@@ -8538,7 +8538,7 @@ button.bg-light:focus {
 a.bg-dark:hover, a.bg-dark:focus,
 button.bg-dark:hover,
 button.bg-dark:focus {
-  background-color: #1d2124 !important;
+  background-color: rgb(29.1379310345, 32.5, 35.8620689655) !important;
 }
 
 .bg-black {
@@ -8558,7 +8558,7 @@ button.bg-black:focus {
 a.bg-instagram:hover, a.bg-instagram:focus,
 button.bg-instagram:hover,
 button.bg-instagram:focus {
-  background-color: #d31e40 !important;
+  background-color: rgb(211.1513761468, 29.8486238532, 64.119266055) !important;
 }
 
 .bg-facebook {
@@ -8568,7 +8568,7 @@ button.bg-instagram:focus {
 a.bg-facebook:hover, a.bg-facebook:focus,
 button.bg-facebook:hover,
 button.bg-facebook:focus {
-  background-color: #2d4474 !important;
+  background-color: rgb(44.8066037736, 67.5896226415, 116.1933962264) !important;
 }
 
 .bg-messenger {
@@ -8578,7 +8578,7 @@ button.bg-facebook:focus {
 a.bg-messenger:hover, a.bg-messenger:focus,
 button.bg-messenger:hover,
 button.bg-messenger:focus {
-  background-color: #006acc !important;
+  background-color: rgb(0, 105.6, 204) !important;
 }
 
 .bg-youtube {
@@ -8588,7 +8588,7 @@ button.bg-messenger:focus {
 a.bg-youtube:hover, a.bg-youtube:focus,
 button.bg-youtube:hover,
 button.bg-youtube:focus {
-  background-color: #a11918 !important;
+  background-color: rgb(160.6991525424, 25.0847457627, 24.3008474576) !important;
 }
 
 .bg-twitter {
@@ -8598,7 +8598,7 @@ button.bg-youtube:focus {
 a.bg-twitter:hover, a.bg-twitter:focus,
 button.bg-twitter:hover,
 button.bg-twitter:focus {
-  background-color: #2795e9 !important;
+  background-color: rgb(38.6363636364, 149.3636363636, 233.3636363636) !important;
 }
 
 .bg-linkedin {
@@ -8608,7 +8608,7 @@ button.bg-twitter:focus {
 a.bg-linkedin:hover, a.bg-linkedin:focus,
 button.bg-linkedin:hover,
 button.bg-linkedin:focus {
-  background-color: #005582 !important;
+  background-color: rgb(0, 85.4696132597, 130) !important;
 }
 
 .bg-snapchat {
@@ -8618,7 +8618,7 @@ button.bg-linkedin:focus {
 a.bg-snapchat:hover, a.bg-snapchat:focus,
 button.bg-snapchat:hover,
 button.bg-snapchat:focus {
-  background-color: #ccca00 !important;
+  background-color: rgb(204, 201.6, 0) !important;
 }
 
 .bg-whatsapp {
@@ -8628,7 +8628,7 @@ button.bg-snapchat:focus {
 a.bg-whatsapp:hover, a.bg-whatsapp:focus,
 button.bg-whatsapp:hover,
 button.bg-whatsapp:focus {
-  background-color: #1da851 !important;
+  background-color: rgb(29.3911290323, 167.6088709677, 81.0241935484) !important;
 }
 
 .bg-skype {
@@ -8638,7 +8638,7 @@ button.bg-whatsapp:focus {
 a.bg-skype:hover, a.bg-skype:focus,
 button.bg-skype:hover,
 button.bg-skype:focus {
-  background-color: #008abd !important;
+  background-color: rgb(0, 137.8125, 189) !important;
 }
 
 .bg-gray-100 {
@@ -8648,7 +8648,7 @@ button.bg-skype:focus {
 a.bg-gray-100:hover, a.bg-gray-100:focus,
 button.bg-gray-100:hover,
 button.bg-gray-100:focus {
-  background-color: #dae0e5 !important;
+  background-color: rgb(218.25, 223.5, 228.75) !important;
 }
 
 .bg-gray-200 {
@@ -8658,7 +8658,7 @@ button.bg-gray-100:focus {
 a.bg-gray-200:hover, a.bg-gray-200:focus,
 button.bg-gray-200:hover,
 button.bg-gray-200:focus {
-  background-color: #cbd3da !important;
+  background-color: rgb(203.4736842105, 210.5, 217.5263157895) !important;
 }
 
 .bg-gray-300 {
@@ -8668,7 +8668,7 @@ button.bg-gray-200:focus {
 a.bg-gray-300:hover, a.bg-gray-300:focus,
 button.bg-gray-300:hover,
 button.bg-gray-300:focus {
-  background-color: #c1c9d0 !important;
+  background-color: rgb(192.9827586207, 200.5, 208.0172413793) !important;
 }
 
 .bg-gray-400 {
@@ -8678,7 +8678,7 @@ button.bg-gray-300:focus {
 a.bg-gray-400:hover, a.bg-gray-400:focus,
 button.bg-gray-400:hover,
 button.bg-gray-400:focus {
-  background-color: #b1bbc4 !important;
+  background-color: rgb(176.9418604651, 186.5, 196.0581395349) !important;
 }
 
 .bg-gray-500 {
@@ -8688,7 +8688,7 @@ button.bg-gray-400:focus {
 a.bg-gray-500:hover, a.bg-gray-500:focus,
 button.bg-gray-500:hover,
 button.bg-gray-500:focus {
-  background-color: #919ca6 !important;
+  background-color: rgb(144.7432432432, 155.5, 166.2567567568) !important;
 }
 
 .bg-gray-600 {
@@ -8698,7 +8698,7 @@ button.bg-gray-500:focus {
 a.bg-gray-600:hover, a.bg-gray-600:focus,
 button.bg-gray-600:hover,
 button.bg-gray-600:focus {
-  background-color: #545b62 !important;
+  background-color: rgb(84.3605150215, 91.3905579399, 97.6394849785) !important;
 }
 
 .bg-gray-700 {
@@ -8708,7 +8708,7 @@ button.bg-gray-600:focus {
 a.bg-gray-700:hover, a.bg-gray-700:focus,
 button.bg-gray-700:hover,
 button.bg-gray-700:focus {
-  background-color: #32373b !important;
+  background-color: rgb(49.73125, 54.5, 59.26875) !important;
 }
 
 .bg-gray-800 {
@@ -8718,7 +8718,7 @@ button.bg-gray-700:focus {
 a.bg-gray-800:hover, a.bg-gray-800:focus,
 button.bg-gray-800:hover,
 button.bg-gray-800:focus {
-  background-color: #1d2124 !important;
+  background-color: rgb(29.1379310345, 32.5, 35.8620689655) !important;
 }
 
 .bg-gray-900 {
@@ -8728,7 +8728,7 @@ button.bg-gray-800:focus {
 a.bg-gray-900:hover, a.bg-gray-900:focus,
 button.bg-gray-900:hover,
 button.bg-gray-900:focus {
-  background-color: #0a0c0d !important;
+  background-color: rgb(10.2567567568, 11.5, 12.7432432432) !important;
 }
 
 .bg-bootstrap {
@@ -8738,7 +8738,7 @@ button.bg-gray-900:focus {
 a.bg-bootstrap:hover, a.bg-bootstrap:focus,
 button.bg-bootstrap:hover,
 button.bg-bootstrap:focus {
-  background-color: #3e2c5a !important;
+  background-color: rgb(62.2918918919, 44.1837837838, 89.8162162162) !important;
 }
 
 .bg-white {
@@ -13112,7 +13112,7 @@ button.bg-bootstrap:focus {
 }
 
 a.text-primary:hover, a.text-primary:focus {
-  color: #027ce1 !important;
+  color: rgb(2.2087378641, 123.6893203883, 225.2912621359) !important;
 }
 
 .text-secondary {
@@ -13120,7 +13120,7 @@ a.text-primary:hover, a.text-primary:focus {
 }
 
 a.text-secondary:hover, a.text-secondary:focus {
-  color: #181c23 !important;
+  color: rgb(24.0625, 27.5625, 35.4375) !important;
 }
 
 .text-success {
@@ -13128,7 +13128,7 @@ a.text-secondary:hover, a.text-secondary:focus {
 }
 
 a.text-success:hover, a.text-success:focus {
-  color: #19692c !important;
+  color: rgb(25.2173913043, 105.2826086957, 43.5) !important;
 }
 
 .text-info {
@@ -13136,7 +13136,7 @@ a.text-success:hover, a.text-success:focus {
 }
 
 a.text-info:hover, a.text-info:focus {
-  color: #0f6674 !important;
+  color: rgb(14.5, 102.1304347826, 116) !important;
 }
 
 .text-warning {
@@ -13144,7 +13144,7 @@ a.text-info:hover, a.text-info:focus {
 }
 
 a.text-warning:hover, a.text-warning:focus {
-  color: #ba8b00 !important;
+  color: rgb(185.5, 139.125, 0) !important;
 }
 
 .text-danger {
@@ -13152,7 +13152,7 @@ a.text-warning:hover, a.text-warning:focus {
 }
 
 a.text-danger:hover, a.text-danger:focus {
-  color: #a71d2a !important;
+  color: rgb(167.4810126582, 29.0189873418, 42.2848101266) !important;
 }
 
 .text-light {
@@ -13160,7 +13160,7 @@ a.text-danger:hover, a.text-danger:focus {
 }
 
 a.text-light:hover, a.text-light:focus {
-  color: #cbd3da !important;
+  color: rgb(203.375, 210.75, 218.125) !important;
 }
 
 .text-dark {
@@ -13168,7 +13168,7 @@ a.text-light:hover, a.text-light:focus {
 }
 
 a.text-dark:hover, a.text-dark:focus {
-  color: #121416 !important;
+  color: rgb(17.7068965517, 19.75, 21.7931034483) !important;
 }
 
 .text-black {
@@ -13184,7 +13184,7 @@ a.text-black:hover, a.text-black:focus {
 }
 
 a.text-instagram:hover, a.text-instagram:focus {
-  color: #bd1b39 !important;
+  color: rgb(188.8096330275, 26.6903669725, 57.3348623853) !important;
 }
 
 .text-facebook {
@@ -13192,7 +13192,7 @@ a.text-instagram:hover, a.text-instagram:focus {
 }
 
 a.text-facebook:hover, a.text-facebook:focus {
-  color: #263962 !important;
+  color: rgb(37.7099056604, 56.8844339623, 97.7900943396) !important;
 }
 
 .text-messenger {
@@ -13200,7 +13200,7 @@ a.text-facebook:hover, a.text-facebook:focus {
 }
 
 a.text-messenger:hover, a.text-messenger:focus {
-  color: #005cb3 !important;
+  color: rgb(0, 92.4, 178.5) !important;
 }
 
 .text-youtube {
@@ -13208,7 +13208,7 @@ a.text-messenger:hover, a.text-messenger:focus {
 }
 
 a.text-youtube:hover, a.text-youtube:focus {
-  color: #8b1615 !important;
+  color: rgb(138.5487288136, 21.6271186441, 20.9512711864) !important;
 }
 
 .text-twitter {
@@ -13216,7 +13216,7 @@ a.text-youtube:hover, a.text-youtube:focus {
 }
 
 a.text-twitter:hover, a.text-twitter:focus {
-  color: #1689e0 !important;
+  color: rgb(22.4090909091, 137.0909090909, 224.0909090909) !important;
 }
 
 .text-linkedin {
@@ -13224,7 +13224,7 @@ a.text-twitter:hover, a.text-twitter:focus {
 }
 
 a.text-linkedin:hover, a.text-linkedin:focus {
-  color: #004569 !important;
+  color: rgb(0, 68.7044198895, 104.5) !important;
 }
 
 .text-snapchat {
@@ -13232,7 +13232,7 @@ a.text-linkedin:hover, a.text-linkedin:focus {
 }
 
 a.text-snapchat:hover, a.text-snapchat:focus {
-  color: #b3b000 !important;
+  color: rgb(178.5, 176.4, 0) !important;
 }
 
 .text-whatsapp {
@@ -13240,7 +13240,7 @@ a.text-snapchat:hover, a.text-snapchat:focus {
 }
 
 a.text-whatsapp:hover, a.text-whatsapp:focus {
-  color: #1a9247 !important;
+  color: rgb(25.5866935484, 145.9133064516, 70.5362903226) !important;
 }
 
 .text-skype {
@@ -13248,7 +13248,7 @@ a.text-whatsapp:hover, a.text-whatsapp:focus {
 }
 
 a.text-skype:hover, a.text-skype:focus {
-  color: #0077a4 !important;
+  color: rgb(0, 119.21875, 163.5) !important;
 }
 
 .text-gray-100 {
@@ -13256,7 +13256,7 @@ a.text-skype:hover, a.text-skype:focus {
 }
 
 a.text-gray-100:hover, a.text-gray-100:focus {
-  color: #cbd3da !important;
+  color: rgb(203.375, 210.75, 218.125) !important;
 }
 
 .text-gray-200 {
@@ -13264,7 +13264,7 @@ a.text-gray-100:hover, a.text-gray-100:focus {
 }
 
 a.text-gray-200:hover, a.text-gray-200:focus {
-  color: #bdc6cf !important;
+  color: rgb(188.7105263158, 197.75, 206.7894736842) !important;
 }
 
 .text-gray-300 {
@@ -13272,7 +13272,7 @@ a.text-gray-200:hover, a.text-gray-200:focus {
 }
 
 a.text-gray-300:hover, a.text-gray-300:focus {
-  color: #b2bcc5 !important;
+  color: rgb(178.474137931, 187.75, 197.025862069) !important;
 }
 
 .text-gray-400 {
@@ -13280,7 +13280,7 @@ a.text-gray-300:hover, a.text-gray-300:focus {
 }
 
 a.text-gray-400:hover, a.text-gray-400:focus {
-  color: #a2aeb9 !important;
+  color: rgb(162.4127906977, 173.75, 185.0872093023) !important;
 }
 
 .text-gray-500 {
@@ -13288,7 +13288,7 @@ a.text-gray-400:hover, a.text-gray-400:focus {
 }
 
 a.text-gray-500:hover, a.text-gray-500:focus {
-  color: #838f9b !important;
+  color: rgb(130.6148648649, 142.75, 154.8851351351) !important;
 }
 
 .text-gray-600 {
@@ -13296,7 +13296,7 @@ a.text-gray-500:hover, a.text-gray-500:focus {
 }
 
 a.text-gray-600:hover, a.text-gray-600:focus {
-  color: #494f54 !important;
+  color: rgb(72.5407725322, 78.5858369099, 83.9592274678) !important;
 }
 
 .text-gray-700 {
@@ -13304,7 +13304,7 @@ a.text-gray-600:hover, a.text-gray-600:focus {
 }
 
 a.text-gray-700:hover, a.text-gray-700:focus {
-  color: #262a2d !important;
+  color: rgb(38.096875, 41.75, 45.403125) !important;
 }
 
 .text-gray-800 {
@@ -13312,7 +13312,7 @@ a.text-gray-700:hover, a.text-gray-700:focus {
 }
 
 a.text-gray-800:hover, a.text-gray-800:focus {
-  color: #121416 !important;
+  color: rgb(17.7068965517, 19.75, 21.7931034483) !important;
 }
 
 .text-gray-900 {
@@ -13328,7 +13328,7 @@ a.text-gray-900:hover, a.text-gray-900:focus {
 }
 
 a.text-bootstrap:hover, a.text-bootstrap:focus {
-  color: #322449 !important;
+  color: rgb(50.4378378378, 35.7756756757, 72.7243243243) !important;
 }
 
 .text-body {
@@ -13508,7 +13508,7 @@ h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
   color: #373F51;
 }
 h1 a:hover, h2 a:hover, h3 a:hover, h4 a:hover, h5 a:hover, h6 a:hover {
-  color: #56627f;
+  color: rgb(85.9375, 98.4375, 126.5625);
   -webkit-text-decoration-line: none;
           text-decoration-line: none;
 }
@@ -13590,7 +13590,7 @@ a[class^=social-media-round-]:before {
   background-color: #3b5999;
 }
 .social-media-round-facebook:hover:before {
-  background-color: #4d70ba;
+  background-color: rgb(76.7405660377, 111.6933962264, 186.2594339623);
 }
 
 .social-media-round-messenger:before {
@@ -13603,7 +13603,7 @@ a[class^=social-media-round-]:before {
   background-color: #0084ff;
 }
 .social-media-round-messenger:hover:before {
-  background-color: #339dff;
+  background-color: rgb(51, 156.6, 255);
 }
 
 .social-media-round-instagram:before {
@@ -13616,7 +13616,7 @@ a[class^=social-media-round-]:before {
   background-color: #e4405f;
 }
 .social-media-round-instagram:hover:before {
-  background-color: #ea6d84;
+  background-color: rgb(234.3165137615, 108.6834862385, 132.4311926606);
 }
 
 .social-media-round-twitter:before {
@@ -13629,7 +13629,7 @@ a[class^=social-media-round-]:before {
   background-color: #55acee;
 }
 .social-media-round-twitter:hover:before {
-  background-color: #83c3f3;
+  background-color: rgb(131.3636363636, 194.6363636364, 242.6363636364);
 }
 
 .social-media-round-whatsapp:before {
@@ -13642,7 +13642,7 @@ a[class^=social-media-round-]:before {
   background-color: #25D366;
 }
 .social-media-round-whatsapp:hover:before {
-  background-color: #4be083;
+  background-color: rgb(75.4798387097, 223.5201612903, 130.7822580645);
 }
 
 .social-media-round-youtube:before {
@@ -13655,7 +13655,7 @@ a[class^=social-media-round-]:before {
   background-color: #cd201f;
 }
 .social-media-round-youtube:hover:before {
-  background-color: #e23e3d;
+  background-color: rgb(225.7076271186, 62.2372881356, 61.2923728814);
 }
 
 .social-media-round-linkedin:before {
@@ -13668,7 +13668,7 @@ a[class^=social-media-round-]:before {
   background-color: #0077B5;
 }
 .social-media-round-linkedin:hover:before {
-  background-color: #0099e8;
+  background-color: rgb(0, 152.5303867403, 232);
 }
 
 .social-media-round-skype:before {
@@ -13681,7 +13681,7 @@ a[class^=social-media-round-]:before {
   background-color: #00AFF0;
 }
 .social-media-round-skype:hover:before {
-  background-color: #24c4ff;
+  background-color: rgb(36, 195.6875, 255);
 }
 
 .social-media-round-snapchat:before {
@@ -13691,10 +13691,10 @@ a[class^=social-media-round-]:before {
           mask-size: contain;
   -webkit-mask-repeat: no-repeat;
           mask-repeat: no-repeat;
-  background-color: #ccca00;
+  background-color: rgb(204, 201.6, 0);
 }
 .social-media-round-snapchat:hover:before {
-  background-color: #e6e300;
+  background-color: rgb(229.5, 226.8, 0);
 }
 
 /* ---------------------------------------------------------------------------*/
@@ -13729,7 +13729,7 @@ article.node .node-readmore:before {
   margin-right: 0.5rem;
 }
 article.node .node-readmore:hover:before {
-  background-color: #027ce1;
+  background-color: rgb(2.2087378641, 123.6893203883, 225.2912621359);
 }
 article.node ul:not([class]) {
   padding-left: 1rem;
@@ -14529,7 +14529,7 @@ body.cke_editable p.dropcaps::first-letter {
   color: #fff;
 }
 .block-local-tasks-block li.active:hover {
-  background-color: #028afb;
+  background-color: rgb(2.4563106796, 137.5533980583, 250.5436893204);
 }
 .block-local-tasks-block li:hover {
   border-color: #33a1fd;
@@ -14627,7 +14627,7 @@ select {
 }
 .wrapper-input-file input + label:hover,
 .wrapper-input-file input:focus + label {
-  background-color: #028afb;
+  background-color: rgb(2.4563106796, 137.5533980583, 250.5436893204);
 }
 
 /* ---------------------------------------------------------------------------*/
@@ -15105,7 +15105,7 @@ footer [id*=mailchimp-signup-subscribe-block] [id*=mailchimp-newsletter] {
   transition: all 0.2s ease-in-out;
 }
 #page-footer-sub a:hover {
-  color: #d9d9d9;
+  color: rgb(216.75, 216.75, 216.75);
 }
 
 /* ---------------------------------------------------------------------------*/
@@ -15445,7 +15445,7 @@ main {
   font-size: 1rem;
 }
 #menu-main .dropdown-menu .dropdown-item:hover {
-  background-color: #66b8fd;
+  background-color: rgb(101.5048543689, 184.2718446602, 253.4951456311);
 }
 #menu-main .navbar-brand {
   font-size: 1.5rem;
@@ -15809,7 +15809,7 @@ ol.breadcrumb .breadcrumb-item {
   top: -25px;
 }
 .path-frontpage .node--sticky:hover:after {
-  background-color: #fea860;
+  background-color: rgb(253.6455696203, 167.6392405063, 95.8544303797);
 }
 .path-frontpage article.node > h2 {
   margin-top: 0.5rem;
@@ -15831,7 +15831,7 @@ ol.breadcrumb .breadcrumb-item {
   margin-right: 0.25rem;
 }
 .path-frontpage article.node > h2:hover:before {
-  background-color: #027ce1;
+  background-color: rgb(2.2087378641, 123.6893203883, 225.2912621359);
 }
 .path-frontpage article.node .text-formatted {
   text-align: justify;
@@ -16136,7 +16136,7 @@ ol.breadcrumb .breadcrumb-item {
 }
 .form-register .wrapper-input-file input + label:hover,
 .form-register .wrapper-input-file input:focus + label {
-  background-color: #028afb;
+  background-color: rgb(2.4563106796, 137.5533980583, 250.5436893204);
 }
 .form-register #edit-user-picture-0--label {
   margin-bottom: 1rem;
@@ -16198,7 +16198,7 @@ ol.breadcrumb .breadcrumb-item {
 .path-activity .marker {
   color: #fff;
   margin-left: 0.5rem;
-  background-color: #e4606d;
+  background-color: rgb(227.5316455696, 96.4683544304, 109.0253164557);
   padding: 0.1rem 0.4rem;
 }
 
@@ -16547,7 +16547,7 @@ form.civiremote-event-register-form .form-item[data-drupal-selector=edit-confirm
 .civiremote-event-session-info {
   width: 100%;
   margin-bottom: 1rem;
-  color: #90a0b0;
+  color: rgb(143.875, 159.75, 175.625);
   border: 1px solid #ced4da;
 }
 .civiremote-event-session-info th,
@@ -16662,7 +16662,7 @@ form .custom-control {
 }
 
 #page-content {
-  overflow: initial !important;
+  overflow: initial;
 }
 
 .view .table-responsive {
@@ -16770,6 +16770,11 @@ form .custom-control {
 }
 .form--inline .form-item {
   float: none;
+}
+
+.custom-file {
+  display: block;
+  height: unset;
 }
 
 .js .dropbutton-widget {

--- a/assets/scss/drupal/form/_form-global.scss
+++ b/assets/scss/drupal/form/_form-global.scss
@@ -102,3 +102,9 @@
     float: none;
   }
 }
+
+// Set values of .custom-file as of .custom-control
+.custom-file {
+  display: block; // Override inline-block.
+  height: unset; // In upstream it is set to $input-height, though we need space for label and input.
+}


### PR DESCRIPTION
Follow up of #12.

In upstream `height` of `.custom-file` is set to a fix value not including the height of the label. Following content might be overlapped depending on styling sub themes:
![image](https://github.com/user-attachments/assets/70172ea3-b047-4e2a-a58c-435772f0c502)

By unsetting `height` the browser calculates the correct height (like for other divs with `.custom-control`).

The same form element as above with the change:
![image](https://github.com/user-attachments/assets/a43021ac-8693-4594-ac5d-d21302a7c91b)

Note: The diff of `style.css` is rather large because recent versions of the dependencies use `rgb()` instead of hex notation for colors.
