### PR TITLE
Declare theme library dependencies for custom-styling for retaining desired load order of assets

### DIFF
--- a/bfd_systopia.info.yml
+++ b/bfd_systopia.info.yml
@@ -15,6 +15,7 @@ libraries-override:
         //fonts.googleapis.com/css?family=Roboto:300,400,500,700,900&display=swap: vendor/googlefonts/Roboto/style.css
     js:
       //stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js: vendor/bootstrap/js/bootstrap.min.js
+  bootstrap_for_drupal/custom-styling: bfd_systopia/custom-styling
 
 regions:
   header_special: 'Header - special'

--- a/bfd_systopia.libraries.yml
+++ b/bfd_systopia.libraries.yml
@@ -2,3 +2,11 @@ global-styling:
   version: 1.x
   js:
     assets/js/global.js: {}
+
+custom-styling:
+  version: 1.x
+  css:
+    theme:
+      public://bfd-custom.css: {}
+  dependencies:
+    - bootstrap_for_drupal/global-styling


### PR DESCRIPTION
[Drupal 10.4 made asset load order more strictly defined by library dependencies.](https://www.drupal.org/node/3473558) The base theme's ([*Bootstrap for Drupal*](http://drupal.org/project/bfd))`custom-styling` library (allowing a `bfd-custom.css` stylesheet overriding theme stylesheets) does not declare a dependency on the `global-styling` library (containing all the theme stylesheets), thus relying on `custom-styling` being loaded after `global-styling`, which has never been guaranteed and just worked by accident (presumably because of the order of definition in the `*.libraries.yml` file).

A more robust fix would be declaring the dependency in the base theme, which seems to be poorly maintained though. As *bfd_systopia* is being used as a base theme itself, this fixes it at least for this theme and sub-themes.

The PR defines the `custom-styling` library again in *bfd_systopia* and replaces the base theme's library with that. Using `libraries-override` to selectively alter the `dependencies` attribute does not seem to be supported.