### PR TITLE
Remove `core` attribute in theme info file

### DIFF
--- a/bfd_systopia.info.yml
+++ b/bfd_systopia.info.yml
@@ -6,7 +6,6 @@ the best possible experience out of the box. It also aim to be a Bootstrap 4 bas
 with SCSS files provided. Created by octogone.dev using Stable and Classy Themes as a base. <br>
 Bootstrap JS-Code is removed for security reasons. <br>
 Adjusted by SYSTOPIA.de'
-core: 8.x
 core_version_requirement: ^9 || ^10 || ^11
 base theme: false
 libraries:


### PR DESCRIPTION
Fixes `The 'core_version_requirement' constraint (^9 || ^10 || ^11) requires the 'core' key not be set in   
  themes/custom/bfd_systopia/bfd_systopia.info.yml` error.